### PR TITLE
Set license field to Apache 2.0 and proprietary

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,5 @@
     "url" : "git://github.com/RuntimeTools/appmetrics.git"
   },
   "author": "",
-  "license": "proprietary"
+  "license": "Apache-2.0 and proprietary"
 }


### PR DESCRIPTION
The license field is currently "proprietary" even though the project is Apache 2.0 with a proprietary dependency. Setting to "Apache-2.0 and proprietary" better reflects this.

We should really use the SPDX standard, which would be '(Apache-2.0 AND SEE LICENSE IN <filename>)' but that doesn't format well on npmjs.org and doesn't (yet) appear to be used for much. We should change to SPDX when that changes.