### PR TITLE
Raise appmetrics version to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appmetrics",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Node Application Metrics",  
   "bin": { "node-hc": "bin/appmetrics-cli.js" },
   "dependencies": {


### PR DESCRIPTION
Since appmetrics-1.0.0 has been released, we are now working on version 1.0.1 in the master branch.
To access version 1.0.0, use the tag appmetrics-1.0.0 or to access the latest release (currently 1.0.0) use branch latest-release.