### PR TITLE
Set appropriate versions on dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Node Application Metrics",  
   "bin": { "node-hc": "bin/appmetrics-cli.js" },
   "dependencies": {
-    "nan": "1.8.4",
-    "node-gyp": "latest"
+    "nan": "^1.8.4",
+    "node-gyp": "~2"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
node-gyp should be fine to match against any current MAJOR version
         (so 2.x at the moment). This can be specified as "~2" in
         semver.
nan needs to be >= 1.8.4 for io.js support but < 2.0.0 because
     2.0.0 brings breaking changes to the nan APIs. This can be
     specified as "^1.8.4" in semver.