### PR TITLE
Change version to indicate this is not a release level

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appmetrics",
-  "version": "1.0.1",
+  "version": "1.0.1-dev.0",
   "description": "Node Application Metrics",  
   "bin": { "node-hc": "bin/appmetrics-cli.js" },
   "dependencies": {


### PR DESCRIPTION
semver allows for "prerelease" version tags on the end of a
version number to indicate a non-release/development level of
the code.

Using:
  semver 1.0.0 -i prerelease --preid dev
... to increment to the next non-release version after 1.0.0 (with
a tag of "dev") gives the following version "1.0.1-dev.0".