### PR TITLE
Update the download script to allow Mac OS

### DIFF
--- a/download_binaries.js
+++ b/download_binaries.js
@@ -63,10 +63,6 @@ var ensureSupportedOSOrExit = function() {
 	/*
 	 * Check for unsupported operating systems and fail fast
 	 */
-	if (OS == 'darwin') {
-		console.log('Mac OS is not a currently supported platform. Exiting');
-		process.exit(1);
-	}
 	if (OS == 'sunos') {
 		console.log('Smart OS is not a currently supported platform. Exiting');
 		process.exit(1);


### PR DESCRIPTION
Previously the download script would detect and attempt to install
on Mac OS an exit with an error message. Since we are adding Mac OS
support, this is no longer required.

Related to #10