### PR TITLE
Disable stack traces on request events by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Emitted when a request is made of the application that involves one or more moni
         * `type` (String) The type of the request event. This can currently be set to 'HTTP' or 'DB'.
         * `name` (String) The name of the request event. This is the request task, eg. the url, or the method being used.
         * `context` (Object) A map of any additional context information for the request event.
-        * `stack` (String) A stack trace for the event call.
+        * `stack` (String) An optional stack trace for the event call.
         * `children` (Array) An array of child request events that occurred as part of the overall request event. Child request events may include function trace entries, which will have a `type` of null.
         * `duration` (Number) the time taken for the request to complete in ms.
     * `duration` (Number) the time taken for the overall request to complete in ms.

--- a/lib/request.js
+++ b/lib/request.js
@@ -82,7 +82,7 @@ Request.prototype.traceStop = function() {
         this.traceStopped = true;
         var stack = null;
 
-        if( this.timer.timeDelta >= config.minClockStack || this.timer.cpuTimeDelta >= config.minCpuStack ) {
+        if((config.minClockStack != -1) && (this.timer.timeDelta >= config.minClockStack)) {
             this.stack = this.fetchStack();
         }
 
@@ -116,7 +116,7 @@ Request.prototype.stop = function(context) {
         this.timer.stop();
         this.children.forEach( function(c){ c.stop(); });
 
-        if( this.timer.timeDelta >= config.minClockTrace || this.timer.cpuTimeDeltaInMs() >= config.minCpuTrace ) {
+        if((config.minClockTrace != -1) && (this.timer.timeDelta >= config.minClockTrace)) {
             this.traceStart(); // delayed start tracing (will call parent tracing if needed)
             this.traceStop();
         }
@@ -183,7 +183,7 @@ var config = {
 		minClockTrace: 0,
 		minCpuTrace: 0,
 		minCpuStack: 0,
-		minClockStack: 0
+		minClockStack: -1
 }
 	
 exports.setConfig = function (newConfig) {


### PR DESCRIPTION
Issue #43 cover the need to set a sensible default for stack trace generation in request tracking. This should do that by allowing a value of '-1' to be used to disable stack trace generation, and to make that the default.

Additionally I've removed the minCpuStack check - until we implement CPU usage tracking per-request, the check is superfluous.