### PR TITLE
Expose patched method/function name in aspects API

### DIFF
--- a/lib/aspect.js
+++ b/lib/aspect.js
@@ -37,19 +37,19 @@ function aspect(type) {
 			var newFunc;
 			if(type == 'before') {
 				newFunc = function() {
-					hookBefore(this, arguments);
+					hookBefore(this, arguments, methodName);
 					return existing.apply(this, arguments);
 				};
 			}
 			else if(type == "around") {
 				newFunc = function() {
-					hookBefore(this, arguments);
+					hookBefore(this, arguments, methodName);
 					var ret = existing.apply(this, arguments);
 					if(process.version.split('.')[0] == 'v0' && process.version.split('.')[1] < 8){
-						hookAfter(this, arguments, ret);
+						hookAfter(this, arguments, ret, methodName);
 						return ret;
 					}else{
-						return hookAfter(this, arguments, ret);
+						return hookAfter(this, arguments, ret, methodName);
 					}
 				};
 			}
@@ -57,10 +57,10 @@ function aspect(type) {
 				newFunc = function() {
 					var ret = existing.apply(this, arguments);
 					if(process.version.split('.')[0] == 'v0' && process.version.split('.')[1] < 8){
-						hookAfter(this, arguments, ret);
+						hookAfter(this, arguments, ret, methodName);
 						return ret;
 					} else {
-						return hookAfter(this, arguments, ret);
+						return hookAfter(this, arguments, ret, methodName);
 					}
 				};
 			}
@@ -85,7 +85,7 @@ exports.aroundCallback = function(args, hookBefore, hookAfter) {
 		var ret = orig.apply(this, arguments);
 
 		if(hookAfter) {
-			hookAfter(this, arguments);
+			hookAfter(this, arguments, ret);
 		}
 		return ret;
 	};


### PR DESCRIPTION
This provides the "methodName" that's been patched to the function callbacks to the aspects.before(), aspects.after() and aspects.around() calls so that its possible to know which function is being patched if an array of function names was provided.

Its passed as the new last parameter to avoid affecting existing code that uses the aspects calls.