### PR TITLE
Remove checks for Node.js version < 0.8

### DIFF
--- a/lib/aspect.js
+++ b/lib/aspect.js
@@ -45,23 +45,13 @@ function aspect(type) {
 				newFunc = function() {
 					hookBefore(this, arguments, methodName);
 					var ret = existing.apply(this, arguments);
-					if(process.version.split('.')[0] == 'v0' && process.version.split('.')[1] < 8){
-						hookAfter(this, arguments, ret, methodName);
-						return ret;
-					}else{
-						return hookAfter(this, arguments, ret, methodName);
-					}
+					return hookAfter(this, arguments, ret, methodName);
 				};
 			}
 			else if(type == 'after') {
 				newFunc = function() {
 					var ret = existing.apply(this, arguments);
-					if(process.version.split('.')[0] == 'v0' && process.version.split('.')[1] < 8){
-						hookAfter(this, arguments, ret, methodName);
-						return ret;
-					} else {
-						return hookAfter(this, arguments, ret, methodName);
-					}
+					return hookAfter(this, arguments, ret, methodName);
 				};
 			}
 			newFunc.prototype = existing.prototype;


### PR DESCRIPTION
Issue #51 was raised to remove unnecessary calls to check if the Node.js version was less that 0.8. This does just that.

Providing the JIT doesn't optimize out the checks already, this should have a decent effect on performance as the check are done for every end probe.

@tunniclm can you provide a quick review?