### PR TITLE
Remove millisecond duration value

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -125,7 +125,7 @@ Request.prototype.stop = function(context) {
             if (typeof(process.domain.currentRequest) === 'undefined') {
             	// End of a root request, so raise a request event
                 process.domain.exit();
-                am.emit('request', {time: this.timer.startTimeMillis, type: this.type, name: this.name, duration: this.timer.duration, request: this});
+                am.emit('request', {time: this.timer.startTimeMillis, type: this.type, name: this.name, duration: this.timer.timeDelta, request: this});
             }
         } 
     }

--- a/lib/timer.js
+++ b/lib/timer.js
@@ -14,34 +14,15 @@
  * limitations under the License.
  *******************************************************************************/
 
-function clockTime() {
-	var time = process.hrtime();
-	return time[0] * 1000 + (time[1] / 1000000.0);
-}
-
-/*
- * CPU time of requests/events not currently implemented
- */
-function clockCpuTime() {
-	return 0;
-}
-
 function Timer() {
 	this.startTime = process.hrtime();
 	this.startTimeMillis = Date.now();
-	this.startCpuTime = clockCpuTime();
 }
 
 Timer.prototype.stop = function() {
 	var dur = process.hrtime(this.startTime);
-	this.stopTimeMillis = Date.now();
-	this.timeDelta = this.stopTimeMillis - this.startTimeMillis;
-	this.duration = (dur[0] * 1000) + (dur[1] / 1000000);
+	this.timeDelta = (dur[0] * 1000) + (dur[1] / 1000000);
 	this.cpuTimeDelta = -1;
-}
-
-Timer.prototype.cpuTimeDeltaInMs = function() {
-	return 0;
 }
 
 exports.start = function(){ return new Timer(); };


### PR DESCRIPTION
This cleans up timer.js.

The `duration` value was new in issue #40 and added in case changing `timeDelta` to a higher precision caused an issue. It looks like that's not the case, so we can remove `duration` and assign the value to the original `timeDelta` field.

I've additionally removed `clockTime()`, `clockCpuTime()` and `cpuTimeDeltaInMs()` as they're not used for anything.