### PR TITLE
Improve performance of HttpProbe.filterUrl()

### DIFF
--- a/probes/http-probe.js
+++ b/probes/http-probe.js
@@ -58,10 +58,21 @@ HttpProbe.prototype.attach = function(name, target, am) {
 };
 
 /*
+ * Custom req.url parser that strips out any trailing query
+ */
+var parse = function (url) {
+	['?','#'].forEach(function (separator)  {
+		var index = url.indexOf(separator);
+		if (index !== -1) url = url.substring(0, index);
+	});
+	return url;
+};
+
+/*
  * Ignore requests for URLs which we've been configured via regex to ignore
  */
 HttpProbe.prototype.filterUrl = function(req) {
-    var resultUrl = url.parse( req.url, true ).pathname;
+    var resultUrl = parse(req.url);
     var filters = this.config.filters;
     if (filters.length == 0) return resultUrl;
     


### PR DESCRIPTION
Issue #57 covers the improvement of HttpProbe.filterUrl() performance. This achieves that by replacing the use of Url.parse() with a custom implementation that relies on the fact that we're not passing in a full URL, but only needs to have any query stripped of the end of the URL.

@tunniclm could you review?