### PR TITLE
Global variables in probes can cause requests to be overwritten.

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,9 @@ files.forEach(function (fileName) {
  * Patch the module require function to run the probe attach function
  * for any matching module. This loads the monitoring probes into the modules
  */
-aspect.after(module.__proto__, 'require', function(obj, args, ret) {
+var data = {};
+
+aspect.after(module.__proto__, 'require', data, function(obj, methodName, args, context, ret) {
 	for (var i = 0; i < probes.length; i++) {
 		if (probes[i].name === args[0]) {
 			probes[i].attach(args[0], ret, module.exports);

--- a/lib/aspect.js
+++ b/lib/aspect.js
@@ -14,54 +14,7 @@
  * limitations under the License.
  *******************************************************************************/
 
-function aspect(type) {
-	return function(target, meths, hook1, hook2) {
-		if(!Array.isArray(meths)) {
-			meths = [meths];
-		}
-		
-		meths.forEach(function(methodName) {
-			var existing = target[methodName];
-			if(!existing) return;
- 
-			var hookBefore, hookAfter;
-			if((type == 'before') && hook1) {
-				hookBefore = hook1;
-			} else if(type == "around" && hook1 && hook2) {
-				hookBefore = hook1;
-				hookAfter = hook2;
-			} else if((type == 'after') && hook1) {
-				hookAfter = hook1;
-			}
-
-			var newFunc;
-			if(type == 'before') {
-				newFunc = function() {
-					hookBefore(this, arguments, methodName);
-					return existing.apply(this, arguments);
-				};
-			}
-			else if(type == "around") {
-				newFunc = function() {
-					hookBefore(this, arguments, methodName);
-					var ret = existing.apply(this, arguments);
-					return hookAfter(this, arguments, ret, methodName);
-				};
-			}
-			else if(type == 'after') {
-				newFunc = function() {
-					var ret = existing.apply(this, arguments);
-					return hookAfter(this, arguments, ret, methodName);
-				};
-			}
-			newFunc.prototype = existing.prototype;
-
-			target[methodName] = newFunc;
-		});
-	};
-}
-
-exports.aroundCallback = function(args, hookBefore, hookAfter) {
+exports.aroundCallback = function(args, context, hookBefore, hookAfter) {
 	var position = this.findCallbackArg(args);
 	if(position == undefined) return;
 
@@ -69,17 +22,17 @@ exports.aroundCallback = function(args, hookBefore, hookAfter) {
 
 	args[position] = function() {
 		if(hookBefore) {
-			hookBefore(this, arguments);
+			hookBefore(this, arguments, context);
 		}
 
 		var ret = orig.apply(this, arguments);
 
 		if(hookAfter) {
-			hookAfter(this, arguments, ret);
+			hookAfter(this, arguments, context, ret);
 		}
 		return ret;
 	};
-}
+};
 
 exports.findCallbackArg = function(args) {
 	var position = undefined;
@@ -90,10 +43,64 @@ exports.findCallbackArg = function(args) {
         }
     }
     return position;
-}
+};
 
-exports.before = aspect("before");
+exports.before = function(target, meths, hookBefore) {
+	if(!Array.isArray(meths)) {
+		meths = [meths];
+	}
+	
+	meths.forEach(function(methodName) {
+		var existing = target[methodName];
+		if(!existing) return;
 
-exports.around = aspect("around");
+		var newFunc = function() {
+			var context = {};
+			hookBefore(this, methodName, arguments, context);
+			return existing.apply(this, arguments);
+		};
+		newFunc.prototype = existing.prototype;
 
-exports.after = aspect("after");
+		target[methodName] = newFunc;
+	});
+};
+
+exports.around = function(target, meths, hookBefore, hookAfter) {
+	if(!Array.isArray(meths)) {
+		meths = [meths];
+	}
+	
+	meths.forEach(function(methodName) {
+		var existing = target[methodName];
+		if(!existing) return;
+
+		var newFunc = function() {
+				var context = {};
+				hookBefore(this, methodName, arguments, context);
+				var ret = existing.apply(this, arguments);
+				return hookAfter(this, methodName, arguments, context, ret);
+			};
+		newFunc.prototype = existing.prototype;
+
+		target[methodName] = newFunc;
+	});
+};
+
+exports.after = function(target, meths, context, hookAfter) {
+	if(!Array.isArray(meths)) {
+		meths = [meths];
+	}
+	
+	meths.forEach(function(methodName) {
+		var existing = target[methodName];
+		if(!existing) return;
+
+		var newFunc = function() {
+				var ret = existing.apply(this, arguments);
+				return hookAfter(this, methodName, arguments, context, ret);
+			};
+		newFunc.prototype = existing.prototype;
+
+		target[methodName] = newFunc;
+	});
+};

--- a/lib/probe.js
+++ b/lib/probe.js
@@ -16,6 +16,7 @@
 
 var aspect = require('./aspect.js');
 var request = require('./request.js');
+var timer = require('./timer.js');
 
 function Probe(name) {
 	this.name = name;
@@ -27,7 +28,7 @@ function Probe(name) {
 /*
  * Function to add instrumentation to the target module
  */
-Probe.prototype.attach = function(name, target, hc) {
+Probe.prototype.attach = function(name, target) {
 	return target;
 };
 
@@ -50,18 +51,18 @@ Probe.prototype.setConfig = function (newConfig) {
 /*
  * Lightweight metrics probes
  */
-Probe.prototype.metricsStart = function(req, res, am) {
-	start = Date.now();
-	timer = process.hrtime();
+Probe.prototype.metricsStart = function(probeData) {
+	probeData.timer = timer.start();
 };
 
-Probe.prototype.metricsEnd = function(req, res, am) {
+// Implentors should stop the timer and emit an event.
+Probe.prototype.metricsEnd = function(probeData) {
+	probeData.timer.stop();
 };
 
 /*
  * Heavyweight request probes
  */
-var request = require('../lib/request.js');
 
 Probe.prototype.requestStart = function (req, res, am) {};
 
@@ -99,10 +100,5 @@ Probe.prototype.disable = function() {
 	this.metricsProbeStart = function() {};
 	this.metricsProbeEnd = function() {};
 };
-
-Probe.prototype.getDuration = function() {
-    var end = process.hrtime(timer);
-    return (end[0] * 1000) + (end[1] / 1000000);
-}
 
 module.exports = Probe;

--- a/lib/request.js
+++ b/lib/request.js
@@ -99,7 +99,9 @@ Request.prototype.traceStop = function() {
 
 Request.prototype.start = function() {
     this.active = true;
-    this.timer = timer.start();
+    if( !this.timer ) {
+    	this.timer = timer.start();
+    }
     if (process.domain) {
         process.domain.currentRequest = this;
     }
@@ -167,14 +169,20 @@ function convertLine(line) {
 }
 
 
-exports.startRequest = function( type, name, root ) {
+exports.startRequest = function( type, name, root, eventTimer ) {
     var req = new Request( type, name, root );
+    if( eventTimer ) {
+    	req.timer = eventTimer;
+    }
     req.start();
     return req;
 };
 
-exports.startMethod = function( name ) {
+exports.startMethod = function( name , eventTimer) {
     var req = new Request( null, name );
+    if( eventTimer ) {
+    	req.timer = eventTimer;
+    }
     req.start();
     return req;
 };

--- a/lib/timer.js
+++ b/lib/timer.js
@@ -17,12 +17,16 @@
 function Timer() {
 	this.startTime = process.hrtime();
 	this.startTimeMillis = Date.now();
+	this.timeDelta = -1;
+	this.cpuTimeDelta = -1;
 }
 
 Timer.prototype.stop = function() {
-	var dur = process.hrtime(this.startTime);
-	this.timeDelta = (dur[0] * 1000) + (dur[1] / 1000000);
-	this.cpuTimeDelta = -1;
-}
+	// Prevent the timer being stopped twice.
+	if( this.timeDelta == -1 ) {
+		var dur = process.hrtime(this.startTime);
+		this.timeDelta = (dur[0] * 1000) + (dur[1] / 1000000);
+	}
+};
 
 exports.start = function(){ return new Timer(); };

--- a/probes/trace-probe.js
+++ b/probes/trace-probe.js
@@ -15,7 +15,6 @@
  *******************************************************************************/
 var Probe = require('../lib/probe.js');
 var request = require('../lib/request.js');
-var aspect = require('../lib/aspect');
 var util = require('util');
 var path = require('path');
 


### PR DESCRIPTION
Fix for issue #61 

Correct the use of globals inside the probes and change parameter passing. Update existing probes to and aspects to pass context so that they can maintain state from the initial function call until callbacks are executed without the use of global variables.
Refactor and simplify aspect.js to be clearer.
Allow shared timers between metrics and request probes to prevent duplicate timer objects being created.