### PR TITLE
MQLight probe - initial code and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Node Application Metrics provides the following built-in data collection sources
  HTTP               | HTTP request calls made of the application
  MySQL              | MySQL queries made by the application
  MongoDB            | MongoDB queries made by the application
+ MQLight            | MQLight messages sent and received by the application
  Request tracking   | A tree of application requests, events and optionally trace (disabled by default)
  Function trace     | Tracing of application function calls that occur during a request (disabled by default)
 
@@ -155,14 +156,14 @@ Stops the appmetrics monitoring agent. If the agent is not running this function
 
 ### appmetrics.enable(`type`, `config`)
 Enable data generation of the specified data type.
-* `type` (String) the type of event to start generating data for. Values of 'profiling', 'http', 'mongo', 'mysql', 'requests' and 'trace' are currently supported. As `trace` is added to request data, both `requests` and `trace` must be enabled in order to receive trace data.
+* `type` (String) the type of event to start generating data for. Values of 'profiling', 'http', 'mongo', 'mysql', 'mqlight, 'requests' and 'trace' are currently supported. As `trace` is added to request data, both `requests` and `trace` must be enabled in order to receive trace data.
 * `config` (Object) (optional) configuration map to be added for the data type being enabled. (see *[setConfig](#set-config)*) for more information.
 
 The following data types are disabled by default: `profiling`, `requests`, `trace`
 
 ### appmetrics.disable(`type`)
 Disable data generation of the specified data type.
-* `type` (String) the type of event to stop generating data for. Values of `profiling`, `http`, `mongo`, `mysql`, `requests` and `trace` are currently supported.
+* `type` (String) the type of event to stop generating data for. Values of `profiling`, `http`, `mongo`, `mqlight`, `mysql`, `requests` and `trace` are currently supported.
 
 <a name="set-config"></a>
 ### appmetrics.setConfig(`type`, `config`)
@@ -249,6 +250,17 @@ Emitted when a MongoDB query is made using the `mongodb` module.
     * `time` (Number) the milliseconds when the MongoDB query was made. This can be converted to a Date using `new Date(data.time)`
     * `query` (String) the query made of the MongoDB database.
     * `duration` (Number) the time taken for the MongoDB query to be responded to in ms.
+
+### Event: 'mqlight'
+Emitted when a MQLight message is sent or received.
+* `data` (Object) the data from the MQLight event:
+    * `time` (Number) the time in milliseconds when the MQLight event occurred. This can be converted to a Date using new Date(data.time).
+    * `clientid` (String) the id of the client.
+    * `data` (String) the data sent if a 'send' or 'message', undefined for other calls.  Truncated if longer than 25 characters.
+    * `method` (String) the name of the call or event (will be one of 'send' or 'message').
+    * `topic` (String) the topic on which a message is sent/received.
+    * `qos` (Number) the QoS level for a 'send' call, undefined if not set.
+    * `duration` (Number) the time taken in milliseconds.
 
 ### Event: 'request'
 Emitted when a request is made of the application that involves one or more monitored application level events. Request events are disabled by default.

--- a/probes/mqlight-probe.js
+++ b/probes/mqlight-probe.js
@@ -1,0 +1,156 @@
+/*******************************************************************************
+ * Copyright 2015 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+var Probe = require('../lib/probe.js');
+var aspect = require('../lib/aspect.js');
+var request = require('../lib/request.js');
+var util = require('util');
+var url = require('url');
+var am = require('appmetrics');
+
+/**
+ * Probe to instrument the MQLight npm client
+ */
+function MQLightProbe() {
+	Probe.call(this, 'mqlight');
+}
+util.inherits(MQLightProbe, Probe);
+
+MQLightProbe.prototype.attach = function(name, target) {
+	var that = this;
+	if( name != 'mqlight' ) return target;
+	if(target.__probeAttached__) return;
+	target.__probeAttached__ = true;
+
+	// After 'createClient'
+	aspect.after(target, 'createClient', {}, function(target, methodName, createClientArgs, context, rc) {
+		var thisClient = rc; // the MQLight client that was created
+		// Just monitor 'send' for now as not sure what else will be useful
+		var methods = 'send';
+		// Before one of the above methods is called on the client
+		aspect.around(thisClient, methods, function(target, methodName, args, probeData) {
+			// Start the monitoring for the method
+			that.metricsProbeStart(probeData, methodName, args);
+			that.requestProbeStart(probeData, methodName, args);
+			// Advise the callback for the method.  Will do nothing if no callback is registered
+			aspect.aroundCallback(args, probeData, function(target, callbackArgs, probeData){
+				// method has completed and the callback has been called, so end the monitoring
+				that.metricsProbeEnd(probeData, methodName, args, thisClient);
+				that.requestProbeEnd(probeData, methodName, args, thisClient);
+			});
+		},
+		function(target, methodName, args, probeData, rc) {
+			// If no callback used then end the monitoring after returning from the method instead
+			if (aspect.findCallbackArg(args) == undefined) {
+				that.metricsProbeEnd(probeData, methodName, args, thisClient);
+				that.requestProbeEnd(probeData, methodName, args, thisClient);
+			}
+			return rc;
+		});
+
+		// Advise the callback code that is called when a message is received
+		aspect.before(thisClient, 'on', function(target, methodName, args, probeData) {
+			// only care about 'message' events
+			if(args[0] == 'message') {
+				// Must be a callback so no need to check for it
+				aspect.aroundCallback(args, new Object(), function(obj, callbackArgs, probeData) {
+					that.metricsProbeStart(probeData, 'message', callbackArgs);
+					that.requestProbeStart(probeData, 'message', callbackArgs);
+				}, function (target, callbackArgs, probeData, ret) {
+					// method has completed and the callback has been called, so end the monitoring
+					that.metricsProbeEnd(probeData, 'message', callbackArgs, thisClient);
+					that.requestProbeEnd(probeData, 'message', callbackArgs, thisClient);
+					return ret;
+				});
+			}
+		});
+		return rc;
+	});
+	return target;
+};
+
+/*
+ * Lightweight metrics probe end for MQLight messages
+ */
+MQLightProbe.prototype.metricsEnd = function(probeData, method, methodArgs, client) {
+	probeData.timer.stop();
+	if(method == 'message') {
+		var data = methodArgs[0];
+		if(data.length > 25) {
+			data = data.substring(0, 22) + "...";
+		}
+		var topic = methodArgs[1].message.topic;
+		am.emit('mqlight', {
+			time : probeData.timer.startTimeMillis,
+			clientid : client.id,
+			data : data,
+			method : method,
+			topic : topic,
+			duration : probeData.timer.timeDelta
+		});
+	} else if(method == 'send') {
+		var data = methodArgs[1];
+		if(data.length > 25) {
+			data = data.substring(0, 22) + "...";
+		}
+		var qos;
+		var options; // options are optional - check number of arguments.
+		if(methodArgs.length > 3) {
+			options = methodArgs[2];
+			qos = options[0];
+		}
+		am.emit('mqlight', {
+			time : probeData.timer.startTimeMillis,
+			clientid : client.id,
+			data : data,
+			method : method,
+			topic : methodArgs[0],
+			qos : qos,
+			duration : probeData.timer.timeDelta
+		});
+	}
+};
+
+/*
+ * Heavyweight request probes for MQLight messages
+ */
+MQLightProbe.prototype.requestStart = function (probeData, method, methodArgs) {
+	probeData.req = request.startRequest('MQLight', method, true, probeData.timer);
+};
+
+MQLightProbe.prototype.requestEnd = function (probeData, method, methodArgs, client) {
+	if(method == 'message') {
+		var data = methodArgs[0];
+		if(data.length > 25) {
+			data = data.substring(0, 22) + "...";
+		}
+		var topic = methodArgs[1].message.topic;
+		probeData.req.stop({clientid: client.id, data: data, method: method,  topic: methodArgs[0]});
+	} else if(method == 'send') {
+		var data = methodArgs[1];
+		if(data.length > 25) {
+			data = data.substring(0, 22) + "...";
+		}
+		var qos;
+		var options; // options are optional - check number of arguments.
+		if(methodArgs.length > 3) {
+			options = methodArgs[2];
+			qos = options[0];
+		}
+		probeData.req.stop({clientid: client.id, data: data, method: method,  topic: methodArgs[0], qos: qos});
+	}
+};
+
+module.exports = MQLightProbe;


### PR DESCRIPTION
The MQLight probe has been written as a 'subtype' of Probe according to probe.js, with implementations for attach, metricsEnd, requestStart and requestEnd methods.  Uses aspects to instrument 'send' calls and 'message' events from the application in order to monitor them.

#64 