### PR TITLE
Pass trace context as an object

### DIFF
--- a/probes/trace-probe.js
+++ b/probes/trace-probe.js
@@ -116,26 +116,26 @@ if(lastMethodArg == '') lastMethodArg = 'undefined';
 
                 var sendCb = resArg.send;
                 resArg.send = function() {
-                    req.stop(cxtFunc);
+                    req.stop(cxtFunc());
                     return sendCb.apply(resArg, arguments);
                 }
 
                 var renderCb = resArg.render;
                 resArg.render = function() {
-                    req.stop(cxtFunc);
+                    req.stop(cxtFunc());
                     return renderCb.apply(resArg, arguments);
                 }
             } else {
                 var cb = arguments[arguments.length-1];
                 arguments[arguments.length-1] = function() {
-                    req.stop(cxtFunc);
+                    req.stop(cxtFunc());
                     cb.apply(this, arguments);
                 }
             }
         }
         var res = method.apply(this, arguments);
         if( !isCallback ) {
-            req.stop(cxtFunc);
+            req.stop(cxtFunc());
         }
         return res;
     };


### PR DESCRIPTION
This is the fix for issue #69 

Rather than passing the function that generates the context to `req.stop()` we should be passing the object returned from the object. This is a simple matter of just adding `()`!