### PR TITLE
Pass 'this'parameter to apply call

### DIFF
--- a/probes/trace-probe.js
+++ b/probes/trace-probe.js
@@ -45,7 +45,7 @@ TraceProbe.prototype.attach = function( moduleName, target ) {
         ret = target;
 		if(Object.keys(target.prototype).length==0 && Object.keys(target).length == 0){
 			ret = function () {
-				var rc = target.apply(null, arguments);
+				var rc = target.apply(this, arguments);
 				instrumentMethods(moduleName, rc);
 				return rc;
 			}


### PR DESCRIPTION
This is the fix for issue #71 which causes constructed objects not to be returned if the constructor has been instrumented for trace.

The issue was that we were failing to pass `this` through to the `apply()` call for the instrumented method, which has now been resolved.