### PR TITLE
Agent version incorrect

### DIFF
--- a/src/appmetrics.cpp
+++ b/src/appmetrics.cpp
@@ -269,7 +269,6 @@ NAN_METHOD(start) {
 
 		// Force MQTT on for now
 		loaderApi->setProperty("com.ibm.diagnostics.healthcenter.mqtt", "on");
-
 		loaderApi->start();
 	}
 	if (!initMonitorApi()) {
@@ -562,7 +561,9 @@ void init(Handle<Object> exports, Handle<Object> module) {
 		loaderApi->logMessage(warning, "Failed to load appmetrics.properties file");
 	}
 	loaderApi->setLogLevels();
-	loaderApi->setProperty("agent.version", loaderApi->getAgentVersion().c_str()); // TODO(tunniclm): why is this set here, rather than in HCCore?
+	/* changing this to pass agentcore.version and adding new appmetrics.version for use in the client */
+	loaderApi->setProperty("agentcore.version", loaderApi->getAgentVersion().c_str());
+	loaderApi->setProperty("appmetrics.version", APPMETRICS_VERSION);
 
 	/*
 	 * Log startup message with version information

--- a/src/plugins/node/env/nodeenvplugin.cpp
+++ b/src/plugins/node/env/nodeenvplugin.cpp
@@ -139,6 +139,9 @@ static void GetNodeInformation(uv_async_t *async, int status) {
 		}
 		contentss << '\n';
 		
+		contentss << "appmetrics.version=" << plugin::api.getProperty("appmetrics.version") << '\n'; // eg "1.0.4"
+		contentss << "agentcore.version=" << plugin::api.getProperty("agentcore.version") << '\n'; // eg "3.0.7"
+
 		if (plugin::nodeVendor != "") {
 			contentss << "runtime.vendor=" << plugin::nodeVendor << '\n';
 		}
@@ -182,7 +185,6 @@ extern "C" {
 		uv_async_t *async = new uv_async_t;
 		uv_async_init(uv_default_loop(), async, GetNodeInformation);
 		uv_async_send(async); // close and cleanup in call back
-		
 		return 0;
 	}
 	


### PR DESCRIPTION
I've modified the agent version to be appmetrics.version and also added agentcore.version to make displaying of the data in the health center client clearer when monitoring node. 

Fix for issues  #78