### PR TITLE
Implmenentation of appmetrics probe for the redis npm module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,6 @@ Emitted when a MQLight message is sent or received.
 Emitted when a Redis command is sent.
 * `data` (Object) the data from the Redis event:
     * `time` (Number) the time in milliseconds when the MQLight event occurred. This can be converted to a Date using new Date(data.time).
-    * `args` (Array) A truncated version of the arguments to the Redis command. No more than 10 arguments are returned and string arguments are truncated. Callbacks are not included in the arguments.
     * `cmd` (String) the Redis command sent to the server or 'batch.exec'/'multi.exec' for groups of command sent using batch/multi calls.
     * `duration` (Number) the time taken in milliseconds.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Node Application Metrics provides the following built-in data collection sources
  PostgreSQL         | PostgreSQL queries made by the application
  MQTT               | MQTT messages sent and received by the application
  MQLight            | MQLight messages sent and received by the application
+ Redis              | Redis commands issued by the application
  Request tracking   | A tree of application requests, events and optionally trace (disabled by default)
  Function trace     | Tracing of application function calls that occur during a request (disabled by default)
 
@@ -158,14 +159,14 @@ Stops the appmetrics monitoring agent. If the agent is not running this function
 
 ### appmetrics.enable(`type`, `config`)
 Enable data generation of the specified data type.
-* `type` (String) the type of event to start generating data for. Values of 'profiling', 'http', 'mongo', 'mysql', 'postgresql', 'mqtt', 'mqlight, 'requests' and 'trace' are currently supported. As `trace` is added to request data, both `requests` and `trace` must be enabled in order to receive trace data.
+* `type` (String) the type of event to start generating data for. Values of 'profiling', 'http', 'mongo', 'mysql', 'postgresql', 'mqtt', 'mqlight, 'redis', 'requests' and 'trace' are currently supported. As `trace` is added to request data, both `requests` and `trace` must be enabled in order to receive trace data.
 * `config` (Object) (optional) configuration map to be added for the data type being enabled. (see *[setConfig](#set-config)*) for more information.
 
 The following data types are disabled by default: `profiling`, `requests`, `trace`
 
 ### appmetrics.disable(`type`)
 Disable data generation of the specified data type.
-* `type` (String) the type of event to stop generating data for. Values of `profiling`, `http`, `mongo`, `mqlight`, `postgresql`, `mqtt`, `mysql`, `requests` and `trace` are currently supported.
+* `type` (String) the type of event to stop generating data for. Values of `profiling`, `http`, `mongo`, `mqlight`, `postgresql`, `mqtt`, `mysql`, `redis`, `requests` and `trace` are currently supported.
 
 <a name="set-config"></a>
 ### appmetrics.setConfig(`type`, `config`)
@@ -271,6 +272,14 @@ Emitted when a MQLight message is sent or received.
     * `method` (String) the name of the call or event (will be one of 'send' or 'message').
     * `topic` (String) the topic on which a message is sent/received.
     * `qos` (Number) the QoS level for a 'send' call, undefined if not set.
+    * `duration` (Number) the time taken in milliseconds.
+
+### Event: 'redis'
+Emitted when a Redis command is sent.
+* `data` (Object) the data from the Redis event:
+    * `time` (Number) the time in milliseconds when the MQLight event occurred. This can be converted to a Date using new Date(data.time).
+    * `args` (Array) A truncated version of the arguments to the Redis command. No more than 10 arguments are returned and string arguments are truncated. Callbacks are not included in the arguments.
+    * `cmd` (String) the Redis command sent to the server or 'batch.exec'/'multi.exec' for groups of command sent using batch/multi calls.
     * `duration` (Number) the time taken in milliseconds.
 
 ### Event: 'request'

--- a/probes/redis-probe.js
+++ b/probes/redis-probe.js
@@ -1,0 +1,259 @@
+/*******************************************************************************
+ * Copyright 2015 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * redis://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+var Probe = require('../lib/probe.js');
+var aspect = require('../lib/aspect.js');
+var request = require('../lib/request.js');
+var am = require('appmetrics');
+var util = require('util');
+
+/**
+ * Probe to instrument the redis npm.
+ * 
+ * Events are fired for calls to the basic commands either in upper or lower case
+ * but are always reported as lower case to keep the two sets of events consistent.
+ * 
+ * Calls to batch.exec() and multi.exec() are also instrumented. Their events are
+ * batch.exec and multi.exec to ensure they can be separately tracked.
+ */
+
+function RedisProbe() {
+	Probe.call(this, 'redis');
+}
+util.inherits(RedisProbe, Probe);
+
+RedisProbe.prototype.attach = function(name, target) {
+	var that = this;
+	if( name != 'redis' ) return;
+	if(target.__probeAttached__) return;
+	target.__probeAttached__ = true;
+	var methods = [];
+	[ 'APPEND', 'AUTH', 'BGREWRITEAOF', 'BGSAVE', 'BITCOUNT',
+	  'BITOP', 'BITPOS', 'BLPOP', 'BRPOP', 'BRPOPLPUSH', 'CLIENT',
+	  'CLUSTER', 'COMMAND', 'CONFIG', 'DBSIZE', 'DEBUG', 'DECR',
+	  'DECRBY', 'DEL', 'DISCARD', 'DUMP', 'ECHO', 'EVAL', 'EVALSHA',
+	  'EXISTS', 'EXPIRE', 'EXPIREAT', 'FLUSHALL', 'FLUSHDB',
+	  'GEOADD', 'GEOHASH', 'GEOPOS', 'GEODIST', 'GEORADIUS',
+	  'GEORADIUSBYMEMBER', 'GET', 'GETBIT', 'GETRANGE', 'GETSET', 'HDEL',
+	  'HEXISTS', 'HGET', 'HGETALL', 'HINCRBY', 'HINCRBYFLOAT', 'HKEYS',
+	  'HLEN', 'HMGET', 'HMSET', 'HSET', 'HSETNX', 'HSTRLEN', 'HVALS',
+	  'INCR', 'INCRBY', 'INCRBYFLOAT', 'INFO', 'KEYS', 'LASTSAVE',
+	  'LINDEX', 'LINSERT', 'LLEN', 'LPOP', 'LPUSH', 'LPUSHX', 'LRANGE',
+	  'LREM', 'LSET', 'LTRIM', 'MGET', 'MIGRATE', 'MONITOR', 'MOVE',
+	  'MSET', 'MSETNX', 'OBJECT', 'PERSIST', 'PEXPIRE', 'PEXPIREAT',
+	  'PFADD', 'PFCOUNT', 'PFMERGE', 'PING', 'PSETEX', 'PSUBSCRIBE',
+	  'PUBSUB', 'PTTL', 'PUBLISH', 'PUNSUBSCRIBE', 'QUIT', 'RANDOMKEY',
+	  'RENAME', 'RENAMENX', 'RESTORE', 'ROLE', 'RPOP', 'RPOPLPUSH',
+	  'RPUSH', 'RPUSHX', 'SADD', 'SAVE', 'SCARD', 'SCRIPT', 'SDIFF',
+	  'SDIFFSTORE', 'SELECT', 'SET', 'SETBIT', 'SETEX', 'SETNX',
+	  'SETRANGE', 'SHUTDOWN', 'SINTER', 'SINTERSTORE', 'SISMEMBER',
+	  'SLAVEOF', 'SLOWLOG', 'SMEMBERS', 'SMOVE', 'SORT', 'SPOP',
+	  'SRANDMEMBER', 'SREM', 'STRLEN', 'SUBSCRIBE', 'SUNION',
+	  'SUNIONSTORE', 'SYNC', 'TIME', 'TTL', 'TYPE', 'UNSUBSCRIBE',
+	  'UNWATCH', 'WAIT', 'WATCH', 'ZADD', 'ZCARD', 'ZCOUNT', 'ZINCRBY',
+	  'ZINTERSTORE', 'ZLEXCOUNT', 'ZRANGE', 'ZRANGEBYLEX',
+	  'ZREVRANGEBYLEX', 'ZRANGEBYSCORE', 'ZRANK', 'ZREM',
+	  'ZREMRANGEBYLEX', 'ZREMRANGEBYRANK', 'ZREMRANGEBYSCORE',
+	  'ZREVRANGE', 'ZREVRANGEBYSCORE', 'ZREVRANK', 'ZSCORE',
+	  'ZUNIONSTORE', 'SCAN', 'SSCAN', 'HSCAN', 'ZSCAN' 
+	  ].map(function(m) {
+		  methods.push(m);
+		  methods.push(m.toLowerCase());
+	  });
+
+	/* Instrument the basic set of asynchronous calls.
+	 * Emit events before the callbacks are called, if no
+	 * callback is passed insert one to end the probe timings.
+	 */
+//	aspect.before(target.RedisClient.prototype, methods, function(target, method, methodArgs, probeData) {
+//		var eventName = method.toLowerCase();
+//		that.metricsProbeStart(probeData, eventName, methodArgs);
+//		that.requestProbeStart(probeData, eventName, methodArgs);
+//		/* REDIS commands don't have to have a callback.
+//		 * All redis calls are asynchronous so we need to instrument or add a
+//		 * callback to stop the timer.
+//		 */
+//		if (aspect.findCallbackArg(methodArgs) != undefined) {
+//			aspect.aroundCallback( methodArgs, probeData, function(target, args) {
+//				that.metricsProbeEnd(probeData, eventName, methodArgs);
+//				that.requestProbeEnd(probeData, eventName, methodArgs);
+//			});
+//		} else {
+//			// Use the array function push to append to arguments,
+//			// insert the probeEnd calls directly as the call back.
+//			[].push.call(methodArgs, function(target, args) {
+//				that.metricsProbeEnd(probeData, eventName, methodArgs);
+//				that.requestProbeEnd(probeData, eventName, methodArgs);
+//			});
+//		}
+//
+//	});
+	aspect.around(target.RedisClient.prototype, methods, function(target, method, methodArgs, probeData) {
+		var eventName = method.toLowerCase();
+		that.metricsProbeStart(probeData, eventName, methodArgs);
+		that.requestProbeStart(probeData, eventName, methodArgs);
+		/* REDIS commands don't have to have a callback.
+		 * All redis calls are asynchronous so we need to instrument or add a
+		 * callback to stop the timer.
+		 */
+		if (aspect.findCallbackArg(methodArgs) != undefined) {
+			aspect.aroundCallback( methodArgs, probeData, function(target, args) {
+				that.metricsProbeEnd(probeData, eventName, methodArgs);
+				that.requestProbeEnd(probeData, eventName, methodArgs);
+			});
+		}
+//		else {
+			// Inserting a callback gives us consistent timings between calls that
+			// pass a callback and those that don't. All redis commands can take a
+			// callback so should be safe to do.
+			// However this is not true for other npm modules where inserting a callback
+			// may change behaviour and hence not for other probes so there is a choice
+			// between being consistent with the behaviour for other redis calls or other
+			// probes.
+			// We have chosen to be consistent with other probes but uncomment the code
+			// below, comment out the after function and change this from aspect.around
+			// to aspect.before to change the behaviour.
+			// TODO - Verify this metric is more use to end users.
+//			// Use the array function push to append to arguments,
+//			// insert the probeEnd calls directly as the call back.
+//			[].push.call(methodArgs, function(target, args) {
+//				that.metricsProbeEnd(probeData, eventName, methodArgs);
+//				that.requestProbeEnd(probeData, eventName, methodArgs);
+//			});
+//		}
+
+	}, function(target, method, methodArgs, probeData, rc) {
+		if (aspect.findCallbackArg(methodArgs) == undefined) {
+			var eventName = method.toLowerCase();
+			that.metricsProbeEnd(probeData, eventName, methodArgs);
+			that.requestProbeEnd(probeData, eventName, methodArgs);
+		}
+	});
+
+	/* Monitor all calls made as one batch/multi.exec call as a single event.
+	 * Instrument the exec method on the object returned from client.batch()
+	 * or client.multi()
+	 */
+	aspect.after(target.RedisClient.prototype, ['multi', 'batch'], {}, function(target, mode, args, probeData, client) {
+		// Log the event name as batch.exec or multi.exec
+		var eventName = mode+'.exec';
+		aspect.around( client, ['exec', 'EXEC'],
+				function(target, method, methodArgs, probeData) {
+			that.metricsProbeStart(probeData, eventName, methodArgs);
+			that.requestProbeStart(probeData, eventName, methodArgs);
+			/* REDIS commands don't have to have a callback.
+			 * All redis calls are asynchronous so we need to instrument or add a
+			 * callback to stop the timer.
+			 */
+			var callback = aspect.findCallbackArg(methodArgs);
+			if (callback != undefined) {
+				aspect.aroundCallback( methodArgs, probeData, function() {
+					that.metricsProbeEnd(probeData, eventName, methodArgs);
+					that.requestProbeEnd(probeData, eventName, methodArgs);
+				});
+			}
+//			else {
+//				// Use the array function push to append to arguments,
+//				// insert the probeEnd calls directly as the call back.
+//				[].push.call(methodArgs, function() {
+//					that.metricsProbeEnd(probeData, eventName, methodArgs);
+//					that.requestProbeEnd(probeData, eventName, methodArgs);
+//				});
+//			}
+		}, function(target, method, methodArgs, probeData, rc) {
+			if (aspect.findCallbackArg(methodArgs) == undefined) {
+				that.metricsProbeEnd(probeData, eventName, methodArgs);
+				that.requestProbeEnd(probeData, eventName, methodArgs);
+			}
+		});
+		return client;
+	});
+	return target;
+};
+
+function truncateArgsArray(methodArgs) {
+	var argCount = 0;
+	var argsArray = [];
+	/* Arguments to redis commands can be either an array of arguments followed by
+	 * a callback or a variable number of args followed by a callback.
+	 * The callback is optional.
+	 */
+	if(Array.isArray(methodArgs[0])) {
+		methodArgs = methodArgs[0];
+	}
+	for( var index in methodArgs ) {
+		var arg = methodArgs[index];
+		
+		// Have reached callback. (All preceding arguments *should* be strings.)
+		if( typeof arg === 'function' ) {
+			break;
+		}
+		// Truncate at 10 arguments.
+		if( argCount == 10 ) {
+			break;
+		}
+		
+		// Make sure we truncate strings.
+		if( typeof arg === 'string') {
+			if(arg.length > 25) {
+				arg = arg.substring(0, 22) + '...';
+			}
+		}
+		argsArray.push(arg);
+		argCount++;
+	}
+	if( methodArgs.length > 10 ) {
+		argsArray.push('...');
+	}
+	return argsArray;
+}
+
+/*
+ * Lightweight metrics probe for REDIS requests
+ * 
+ * These provide:
+ * 		time:		time event started
+ * 		cmd:		REDIS method, eg. GET, SET, INCR, etc
+ * 		args:		The args passed in (truncated)
+ * 		duration:	the time for the request to respond
+ */
+
+RedisProbe.prototype.metricsEnd = function(probeData, cmd, methodArgs) {
+	probeData.timer.stop();
+	probeData.argsArray = truncateArgsArray(methodArgs);
+	am.emit('redis', {time: probeData.timer.startTimeMillis, cmd: cmd, args: probeData.argsArray, duration: probeData.timer.timeDelta});
+};
+
+/*
+ * Heavyweight request probes for redis requests
+ * 
+ */
+RedisProbe.prototype.requestStart = function (probeData, cmd, methodArgs) {
+	probeData.req = request.startRequest( 'redis', cmd, false, probeData.timer);
+};
+
+RedisProbe.prototype.requestEnd = function (probeData, method, methodArgs) {
+	var context = {};
+	// Don't re-truncate if we've already done the work.
+	if( probeData.argsArray ) {
+		context.args = probeData.argsArray;
+	} else {
+		context.cmd = cmd;
+		context.args = truncateArgsArray(methodArgs);
+	}
+	probeData.req.stop(context);
+};
+
+module.exports = RedisProbe;

--- a/probes/redis-probe.js
+++ b/probes/redis-probe.js
@@ -82,32 +82,10 @@ RedisProbe.prototype.attach = function(name, target) {
 		 * All redis calls are asynchronous so we need to instrument or add a
 		 * callback to stop the timer.
 		 */
-//		if (aspect.findCallbackArg(methodArgs) != undefined) {
-			aspect.aroundCallback( methodArgs, probeData, function(target, args) {
-				that.metricsProbeEnd(probeData, eventName, methodArgs);
-				that.requestProbeEnd(probeData, eventName, methodArgs);
-			});
-//		}
-//		else {
-			// Inserting a callback gives us consistent timings between calls that
-			// pass a callback and those that don't. All redis commands can take a
-			// callback so should be safe to do.
-			// However this is not true for other npm modules where inserting a callback
-			// may change behaviour and hence not for other probes so there is a choice
-			// between being consistent with the behaviour for other redis calls or other
-			// probes.
-			// We have chosen to be consistent with other probes but uncomment the code
-			// below, comment out the after function and change this from aspect.around
-			// to aspect.before to change the behaviour.
-			// TODO - Verify this metric is more use to end users.
-//			// Use the array function push to append to arguments,
-//			// insert the probeEnd calls directly as the call back.
-//			[].push.call(methodArgs, function(target, args) {
-//				that.metricsProbeEnd(probeData, eventName, methodArgs);
-//				that.requestProbeEnd(probeData, eventName, methodArgs);
-//			});
-//		}
-
+		aspect.aroundCallback( methodArgs, probeData, function(target, args) {
+			that.metricsProbeEnd(probeData, eventName, methodArgs);
+			that.requestProbeEnd(probeData, eventName, methodArgs);
+		});
 	}, function(target, method, methodArgs, probeData, rc) {
 		if (aspect.findCallbackArg(methodArgs) == undefined) {
 			var eventName = method.toLowerCase();
@@ -131,21 +109,10 @@ RedisProbe.prototype.attach = function(name, target) {
 			 * All redis calls are asynchronous so we need to instrument or add a
 			 * callback to stop the timer.
 			 */
-//			var callback = aspect.findCallbackArg(methodArgs);
-//			if (callback != undefined) {
-				aspect.aroundCallback( methodArgs, probeData, function() {
-					that.metricsProbeEnd(probeData, eventName, methodArgs);
-					that.requestProbeEnd(probeData, eventName, methodArgs);
-				});
-//			}
-//			else {
-//				// Use the array function push to append to arguments,
-//				// insert the probeEnd calls directly as the call back.
-//				[].push.call(methodArgs, function() {
-//					that.metricsProbeEnd(probeData, eventName, methodArgs);
-//					that.requestProbeEnd(probeData, eventName, methodArgs);
-//				});
-//			}
+			aspect.aroundCallback( methodArgs, probeData, function() {
+				that.metricsProbeEnd(probeData, eventName, methodArgs);
+				that.requestProbeEnd(probeData, eventName, methodArgs);
+			});
 		}, function(target, method, methodArgs, probeData, rc) {
 			if (aspect.findCallbackArg(methodArgs) == undefined) {
 				that.metricsProbeEnd(probeData, eventName, methodArgs);

--- a/tests/redis-probe-test.js
+++ b/tests/redis-probe-test.js
@@ -202,7 +202,7 @@ batchObject2.exec();
 var batchObject3 = client.batch();
 
 results['BATCH_TEST'] = false;
-var batchObject = client.batch();
+var batchObject = client.BATCH();
 addExpectedEvent('batch.exec');
 batchObject3.set('BATCHKEY', 'BATCHVALUE');
 batchObject3.get('BATCHKEY');
@@ -210,7 +210,7 @@ batchObject3.EXEC(function(err, reply) {
 	results['BATCH_TEST'] = true;
 });
 
-var batchObject4 = client.batch();
+var batchObject4 = client.BATCH();
 
 addExpectedEvent('batch.exec');
 batchObject4.set('BATCHKEY', 'BATCHVALUE2');
@@ -238,7 +238,7 @@ multiObject2.set('multikey', 'multivalue2');
 multiObject2.get('multikey');
 multiObject2.exec();
 
-var multiObject3 = client.multi();
+var multiObject3 = client.MULTI();
 
 results['MULTI_TEST'] = false;
 addExpectedEvent('multi.exec');
@@ -248,7 +248,7 @@ multiObject3.EXEC(function(err, reply) {
 	results['MULTI_TEST'] = true;
 });
 
-var multiObject4 = client.multi();
+var multiObject4 = client.MULTI();
 
 addExpectedEvent('multi.exec');
 multiObject4.set('MULTIKEY', 'MULTIVALUE2');

--- a/tests/redis-probe-test.js
+++ b/tests/redis-probe-test.js
@@ -1,0 +1,314 @@
+/*******************************************************************************
+ * Copyright 2015 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * redis://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+/* A test for the appmetrics redis probe.
+ * It assumes a redis server is running on the local host.
+ * 
+ * It tests that user the probes are triggered for every function
+ * and that user call backs to redis commands are run correctly.
+ * 
+ * Debug code is included commented out for if the test fails.
+ */
+
+var results = {};
+var actualProbeCounts = new Object();
+var expectedProbeCounts = new Object();
+var exitCode = 0;
+
+function addRedisCommandTest(testName, testFunc) {
+	/* Mark test as having failed. */
+	results[testName] = false;
+	testFunc();
+}
+
+/* Setup tracking so we know how many metric events ought to have fired
+ * and can validate that we instrumented methods correctly.
+ */
+function addExpectedEvent(method) {
+//	console.log('Adding expected call to method: ' + method);
+	if (!expectedProbeCounts[method]) {
+		expectedProbeCounts[method] = 0;
+		actualProbeCounts[method] = 0;
+	}
+	expectedProbeCounts[method]++;
+//	console.log('Expected calls to method: ' + method + ' now '
+//			+ expectedProbeCounts[method]);
+}
+
+/* Check the test results on exit and report any failures. 
+ */
+process.on('exit', function(code) {
+	
+	console.log('*** TEST EXITING - Results:');
+	
+	var probesPassed = true;
+	for (method in actualProbeCounts) {
+		if (expectedProbeCounts[method] !== actualProbeCounts[method]) {
+			console.log('** Counts for ' + method + ' did not match, expected '
+					+ expectedProbeCounts[method] + ' actual '
+					+ actualProbeCounts[method]);
+			probesPassed = false;
+		} else {
+			// Uncomment this when debugging.
+//			console.log('Counts for ' + method + ' matched, expected '
+//					+ expectedProbeCounts[method] + ' actual '
+//					+ actualProbeCounts[method]);
+		}
+	}
+	if( !probesPassed ) {
+		console.log('Some probes failed to fire. - FAIL');
+	} else {
+		console.log('All expected probes fired. - PASS');
+	}
+	
+	var passCount = 0;
+	var failCount = 0;
+	for (test in results) {
+//		console.log(test + ': \t' + results[test]);
+		if (!results[test]) {
+			// Make sure we exit with an error if a test failed.
+			console.log('Callback test failure: ' + test);
+			failCount++;
+		} else {
+			passCount++;
+		}
+	}
+	var totalCount = passCount + failCount;
+	if (failCount > 0) {
+		console.log(passCount + ' / ' + totalCount
+				+ ' callbacks ran. - FAIL');
+	} else {
+		console.log(passCount + ' / ' + totalCount
+				+ ' callbacks ran. - PASS');
+	}
+	process.exit(exitCode);
+});
+
+var appmetrics = require('appmetrics');
+
+var monitoring = appmetrics.monitor();
+
+/* A standard callback we can use to confirm when tests have run. */
+monitoring.on('redis', function(data) {
+	actualProbeCounts[data.cmd]++;
+	// Uncomment these when debugging.
+//	console.log('*** Probe callback ***');
+//	console.dir(data, {colors:true, depth:null});
+//	console.log('[method: ' + data.method + ']');
+//	console.log('\t[time: ' + data.time + ']');
+//	console.log('\t[duration: ' + data.duration + ']');
+//	console.log('Incrementing calls for method ' + data.method);
+//	console.log('Callback for method ' + data.method + ' called');
+});
+
+console.log('Requiring redis');
+
+var redis = require('redis');
+
+if (!redis.__probeAttached__) {
+	console.log('Test failed - redis was not instrumented.');
+//	process.exit(1);
+} else {
+	console.log('Test passed - redis was instrumented.');
+}
+console.log('Beginning tests');
+
+/* Connecting the client triggers an info command. */
+addExpectedEvent('info');
+var client = redis.createClient();
+
+/*
+ * Test both lower and upper case basic commands
+ */
+console.log('Async calls');
+results['set_test'] = false;
+addExpectedEvent('set');
+client.set('akey', 'somevalue', function(err, reply) {
+	results['set_test'] = true;
+});
+
+results['SET_TEST'] = false;
+addExpectedEvent('set');
+client.SET('AKEY', 'SOMEVALUE', function(err, reply) {
+	results['SET_TEST'] = true;
+});
+
+results['get_test'] = false;
+addExpectedEvent('get');
+client.get('akey', function(err, reply) {
+	results['get_test'] = true;
+});
+
+results['GET_TEST'] = false;
+addExpectedEvent('get');
+client.GET('AKEY', function(err, reply) {
+	results['GET_TEST'] = true;
+});
+console.log('Async calls done.');
+
+/*
+ * Test basic commands without callbacks.
+ */
+console.log('Sync calls');
+
+addExpectedEvent('set');
+client.set('akey', 'somevalue');
+
+addExpectedEvent('set');
+client.SET('AKEY', 'SOMEVALUE');
+
+addExpectedEvent('get');
+client.get('akey');
+
+addExpectedEvent('get');
+client.GET('AKEY');
+
+console.log('Sync calls done.');
+
+/*
+ * Test batch commands with and without callbacks.
+ * Assuming batch objects aren't safe for re-use.
+ */
+var batchObject1 = client.batch();
+
+results['batch_test'] = false;
+addExpectedEvent('batch.exec');
+batchObject1.set('batchkey', 'batchvalue');
+batchObject1.get('batchkey');
+batchObject1.exec(function(err, reply) {
+	results['batch_test'] = true;
+});
+
+var batchObject2 = client.batch();
+
+addExpectedEvent('batch.exec');
+batchObject2.set('batchkey', 'batchvalue2');
+batchObject2.get('batchkey');
+batchObject2.exec();
+
+var batchObject3 = client.batch();
+
+results['BATCH_TEST'] = false;
+var batchObject = client.batch();
+addExpectedEvent('batch.exec');
+batchObject3.set('BATCHKEY', 'BATCHVALUE');
+batchObject3.get('BATCHKEY');
+batchObject3.EXEC(function(err, reply) {
+	results['BATCH_TEST'] = true;
+});
+
+var batchObject4 = client.batch();
+
+addExpectedEvent('batch.exec');
+batchObject4.set('BATCHKEY', 'BATCHVALUE2');
+batchObject4.get('BATCHKEY');
+batchObject4.EXEC();
+
+/*
+ * Test mutli commands with and without callbacks.
+ * Assuming multi objects aren't safe for re-use.
+ */
+var multiObject1 = client.multi();
+
+results['multi_test'] = false;
+addExpectedEvent('multi.exec');
+multiObject1.set('multikey', 'multivalue');
+multiObject1.get('multikey');
+multiObject1.exec(function(err, reply) {
+	results['multi_test'] = true;
+});
+
+var multiObject2 = client.multi();
+
+addExpectedEvent('multi.exec');
+multiObject2.set('multikey', 'multivalue2');
+multiObject2.get('multikey');
+multiObject2.exec();
+
+var multiObject3 = client.multi();
+
+results['MULTI_TEST'] = false;
+addExpectedEvent('multi.exec');
+multiObject3.set('MULTIKEY', 'MULTIVALUE');
+multiObject3.get('MULTIKEY');
+multiObject3.EXEC(function(err, reply) {
+	results['MULTI_TEST'] = true;
+});
+
+var multiObject4 = client.multi();
+
+addExpectedEvent('multi.exec');
+multiObject4.set('MULTIKEY', 'MULTIVALUE2');
+multiObject4.get('MULTIKEY');
+multiObject4.EXEC();
+
+/* Terminate the client and allow the script to exit.
+ * process.on('exit', ...) will be called and we will
+ * report whether the test passed. 
+ */
+addExpectedEvent('quit');
+client.quit();
+
+/* Test pub/sub monitoring */
+addExpectedEvent('info');
+subClient = redis.createClient();
+addExpectedEvent('info');
+pubClient = redis.createClient();
+
+console.log('Setting up pub/sub:');
+
+subClient.on('subscribe', function (channel, count) {
+	
+	addExpectedEvent('publish');
+	results['publish_test'] = false;
+	pubClient.publish('channel 1', 'message 1', function() {
+		results['publish_test'] = true;
+	});
+	
+	addExpectedEvent('publish');
+	results['PUBLISH_TEST'] = false;
+	pubClient.publish('channel 1', 'message 1', function() {
+		results['PUBLISH_TEST'] = true;
+	});
+	
+	addExpectedEvent('publish');
+	pubClient.publish('channel 1', 'message 2');
+	addExpectedEvent('publish');
+	pubClient.PUBLISH('channel 1', 'last message');
+	
+});
+
+var msg_count = 0;
+subClient.on('message', function (channel, message) {
+	msg_count += 1;
+	if (msg_count === 3) {
+		addExpectedEvent('unsubscribe');
+		subClient.unsubscribe();
+		addExpectedEvent('quit');
+		subClient.quit();
+		addExpectedEvent('quit');
+		pubClient.QUIT();
+	}
+});
+
+results['subscribe_test'] = false;
+addExpectedEvent('subscribe');
+subClient.subscribe('channel 1', function() {
+	results['subscribe_test'] = true;
+});
+console.log('Pub/sub tests started.');
+
+


### PR DESCRIPTION
Add support for monitoring of redis ( for issue #68 )
Provides monitoring for redis commands issued via the client api or via batch/multi objects.
Test case verifies we get the expected number of events and that callbacks are still invoked.
Update README.md to include a description of the redis probe.