### PR TITLE
Remove the call to set the context in requestStart for the mysql and mongo probes.

### DIFF
--- a/probes/mongo-probe.js
+++ b/probes/mongo-probe.js
@@ -108,7 +108,6 @@ MongoProbe.prototype.metricsEnd = function(probeData, method, methodArgs) {
  */
 MongoProbe.prototype.requestStart = function (probeData, target, method, methodArgs) {
 	probeData.req = request.startRequest( 'DB', method + "("+target.collectionName+")", false, probeData.timer );
-	probeData.req.setContext( { query: JSON.stringify(methodArgs[0]) } );
 };
 
 MongoProbe.prototype.requestEnd = function (probeData, method, methodArgs) {

--- a/probes/mysql-probe.js
+++ b/probes/mysql-probe.js
@@ -68,7 +68,6 @@ MySqlProbe.prototype.metricsEnd = function(probeData, method, methodArgs) {
  */
 MySqlProbe.prototype.requestStart = function (probeData, method, methodArgs) {
 	probeData.req = request.startRequest( 'DB', "query", false, probeData.timer );
-	probeData.req.setContext({sql: JSON.stringify(methodArgs[0])});
 };
 
 MySqlProbe.prototype.requestEnd = function (probeData, method, methodArgs) {


### PR DESCRIPTION
This patch should resolve issue #80 

The context is set in requestEnd and doesn't need to be set twice. This saves the cost of one of the JSON.stringify calls.
I removed the one in requestStart as that was being done while the timer was running. The call in requestEnd occurs once the timer has stopped so won't be counted towards the request time.