### PR TITLE
Add support for monitoring MQTT messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Node Application Metrics provides the following built-in data collection sources
  MySQL              | MySQL queries made by the application
  MongoDB            | MongoDB queries made by the application
  PostgreSQL         | PostgreSQL queries made by the application
+ MQTT               | MQTT messages sent and received by the application
  MQLight            | MQLight messages sent and received by the application
  Request tracking   | A tree of application requests, events and optionally trace (disabled by default)
  Function trace     | Tracing of application function calls that occur during a request (disabled by default)
@@ -157,14 +158,14 @@ Stops the appmetrics monitoring agent. If the agent is not running this function
 
 ### appmetrics.enable(`type`, `config`)
 Enable data generation of the specified data type.
-* `type` (String) the type of event to start generating data for. Values of 'profiling', 'http', 'mongo', 'mysql', 'postgresql', 'mqlight, 'requests' and 'trace' are currently supported. As `trace` is added to request data, both `requests` and `trace` must be enabled in order to receive trace data.
+* `type` (String) the type of event to start generating data for. Values of 'profiling', 'http', 'mongo', 'mysql', 'postgresql', 'mqtt', 'mqlight, 'requests' and 'trace' are currently supported. As `trace` is added to request data, both `requests` and `trace` must be enabled in order to receive trace data.
 * `config` (Object) (optional) configuration map to be added for the data type being enabled. (see *[setConfig](#set-config)*) for more information.
 
 The following data types are disabled by default: `profiling`, `requests`, `trace`
 
 ### appmetrics.disable(`type`)
 Disable data generation of the specified data type.
-* `type` (String) the type of event to stop generating data for. Values of `profiling`, `http`, `mongo`, `mqlight`, `postgresql`, `mysql`, `requests` and `trace` are currently supported.
+* `type` (String) the type of event to stop generating data for. Values of `profiling`, `http`, `mongo`, `mqlight`, `postgresql`, `mqtt`, `mysql`, `requests` and `trace` are currently supported.
 
 <a name="set-config"></a>
 ### appmetrics.setConfig(`type`, `config`)
@@ -251,6 +252,15 @@ Emitted when a MongoDB query is made using the `mongodb` module.
     * `time` (Number) the milliseconds when the MongoDB query was made. This can be converted to a Date using `new Date(data.time)`
     * `query` (String) the query made of the MongoDB database.
     * `duration` (Number) the time taken for the MongoDB query to be responded to in ms.
+
+### Event: 'mqtt'
+Emitted when a MQTT message is sent or received.
+* `data` (Object) the data from the MQTT event:
+    * `time` (Number) the time in milliseconds when the MQTT event occurred. This can be converted to a Date using new Date(data.time).
+    * `method` (String) the name of the call or event (will be one of 'publish' or 'message').
+    * `topic` (String) the topic on which a message is published or received.
+    * `qos` (Number) the QoS level for the message.
+    * `duration` (Number) the time taken in milliseconds.
 
 ### Event: 'mqlight'
 Emitted when a MQLight message is sent or received.

--- a/probes/mqtt-probe.js
+++ b/probes/mqtt-probe.js
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright 2015 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+var Probe = require('../lib/probe.js');
+var aspect = require('../lib/aspect.js');
+var request = require('../lib/request.js');
+var util = require('util');
+var am = require('appmetrics');
+
+function MqttProbe() {
+	Probe.call(this, 'mqtt');
+}
+util.inherits(MqttProbe, Probe);
+
+MqttProbe.prototype.attach = function(name, target) {
+	var that = this;
+	if( name != "mqtt" ) return target;
+	target.__ddProbeAttached__ = true;
+
+	aspect.after(target, 'connect', {}, function(target, methodName, methodArgs, context, client) {
+		var methods = 'publish';
+		aspect.around(client, methods,
+			function(target, methodName, methodArgs, context){
+				that.metricsProbeStart(context, methodName, methodArgs);
+				that.requestProbeStart(context, methodName, methodArgs);
+				aspect.aroundCallback(methodArgs, context,
+					function(target, args, context){
+						that.metricsProbeEnd(context, methodName, methodArgs);
+						that.requestProbeEnd(context, methodName, methodArgs);
+					}
+				);
+			},
+			function (target, methodName, methodArgs, context, rc) {
+				if (aspect.findCallbackArg(methodArgs) == undefined) {
+					that.metricsProbeEnd(context, methodName, methodArgs);
+					that.requestProbeEnd(context, methodName, methodArgs);
+				}
+				return rc;
+			}
+		);
+
+		var methods = ['on', 'addListener'];
+		aspect.before(client, methods,
+			function(target, methodName, methodArgs, context) {
+			var eventName = 'message';
+				if(methodArgs[0] !== eventName) return;
+				if (aspect.findCallbackArg(methodArgs) != undefined) {
+					aspect.aroundCallback(methodArgs, context,
+						function(target, args, context){
+							that.metricsProbeStart(context, eventName, methodArgs);
+							that.requestProbeStart(context, eventName, methodArgs);
+						}, 
+						function (target, methodArgs, context, rc) {
+							that.metricsProbeEnd(context, eventName, methodArgs);
+							that.requestProbeEnd(context, eventName, methodArgs);
+							return rc;
+						}
+					);
+				};
+			}
+		);
+		return client;
+	});
+	return target;
+};
+
+/*
+ * Lightweight metrics probe for MQTT messaging
+ * 
+ * These provide:
+ *		time:		time event started
+ *		method:		whether this was a received 'message' or a 'publish'
+ *		topic:		the topic the message was received on
+ *		qos:		the quality of service (QoS) for the message
+ *		duration:	the time for the request to respond
+ */
+MqttProbe.prototype.metricsEnd = function(context, methodName, methodArgs) {
+	context.timer.stop();
+	// default to quality of service (qos) 0, as that's what the mqtt module does
+	var qos = 0;
+	if (methodArgs[2] && (typeof(methodArgs[2]) !== 'function')) {
+		qos = methodArgs[2].qos;
+	}
+	am.emit('mqtt', {time: context.timer.startTimeMillis, method: methodName, topic: methodArgs[0], qos: qos, duration: context.timer.timeDelta});
+};
+
+/*
+ * Heavyweight request probes for MQTT messages
+ */
+MqttProbe.prototype.requestStart = function (context, methodName, methodArgs) {
+	if (methodName === 'message') {
+		context.req = request.startRequest('MQTT', methodName, true, context.timer);
+	} else {
+		context.req = request.startRequest('MQTT', methodName, false, context.timer);
+	}
+};
+
+MqttProbe.prototype.requestEnd = function (context, methodName, methodArgs) {
+	var qos = 0;
+	if (methodArgs[2] && (typeof(methodArgs[2]) !== 'function')) {
+		qos = methodArgs[2].qos;
+	}
+	context.req.stop({topic: methodArgs[0], qos: qos});
+};
+
+module.exports = MqttProbe;


### PR DESCRIPTION
PR for issue #37 to add monitoring for MQTT messaging. Provides both the mqtt-probe.js and an update to the README.md with the new event information.

@tunniclm Can you review? @hhellyeribm has already taken a quick look via my branch as well.