### PR TITLE
Add ability to instrument after constructors

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ var data = {};
 aspect.after(module.__proto__, 'require', data, function(obj, methodName, args, context, ret) {
 	for (var i = 0; i < probes.length; i++) {
 		if (probes[i].name === args[0]) {
-			probes[i].attach(args[0], ret, module.exports);
+			ret = probes[i].attach(args[0], ret, module.exports);
 		}
 		if (probes[i].name === 'trace') {
 			ret = probes[i].attach(args[0], ret);

--- a/lib/aspect.js
+++ b/lib/aspect.js
@@ -104,3 +104,17 @@ exports.after = function(target, meths, context, hookAfter) {
 		target[methodName] = newFunc;
 	});
 };
+
+exports.afterConstructor = function (target, context, hookAfter) {
+	if (typeof(target) === 'function') {
+		var newFunc = function() {
+			var ret = target.apply(null, arguments);
+			return hookAfter(this, '()', arguments, context, ret);
+		};
+		newFunc.prototype = target.prototype;
+		newFunc.exports = target.exports;
+		return newFunc;
+	} else {
+		return target;
+	}
+};

--- a/probes/http-probe.js
+++ b/probes/http-probe.js
@@ -31,7 +31,7 @@ util.inherits(HttpProbe, Probe);
 HttpProbe.prototype.attach = function(name, target) {
 	var that = this;
 	if( name == 'http' ) {
-		if(target.__probeAttached__) return;
+		if(target.__probeAttached__) return target;
 	    target.__probeAttached__ = true;
 	    var methods = ['on', 'addListener'];
 	    
@@ -55,7 +55,7 @@ HttpProbe.prototype.attach = function(name, target) {
 	            }
 	        });
 	    });
-	}	
+	}
 	return target;
 };
 

--- a/probes/redis-probe.js
+++ b/probes/redis-probe.js
@@ -37,7 +37,7 @@ util.inherits(RedisProbe, Probe);
 RedisProbe.prototype.attach = function(name, target) {
 	var that = this;
 	if( name != 'redis' ) return;
-	if(target.__probeAttached__) return;
+	if(target.__probeAttached__) return target;
 	target.__probeAttached__ = true;
 	var methods = [];
 	[ 'APPEND', 'AUTH', 'BGREWRITEAOF', 'BGSAVE', 'BITCOUNT',


### PR DESCRIPTION
PR for issue #92 

This adds a new aspects function to probe after a constructor is run. There will most likely be a need to implement equivalent before and around functions, but I've deferred those for the moment.

Additionally, as we have to return a new module rather than updating an existing one (as the constructor in our use case is the module.exports), there's an updated to index.js where we're handling the instrumentation of the modules. This is to receive the new module back rather than relying on the existing one being updated.

This then required updates to the http and redis probes to make sure they return the module definition.