### PR TITLE
Add support for Memcached monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Node Application Metrics provides the following built-in data collection sources
  PostgreSQL         | PostgreSQL queries made by the application
  MQTT               | MQTT messages sent and received by the application
  MQLight            | MQLight messages sent and received by the application
+ Memcached          | Data that stored or manupulated in Memcached
  Redis              | Redis commands issued by the application
  Request tracking   | A tree of application requests, events and optionally trace (disabled by default)
  Function trace     | Tracing of application function calls that occur during a request (disabled by default)
@@ -159,14 +160,14 @@ Stops the appmetrics monitoring agent. If the agent is not running this function
 
 ### appmetrics.enable(`type`, `config`)
 Enable data generation of the specified data type.
-* `type` (String) the type of event to start generating data for. Values of 'profiling', 'http', 'mongo', 'mysql', 'postgresql', 'mqtt', 'mqlight, 'redis', 'requests' and 'trace' are currently supported. As `trace` is added to request data, both `requests` and `trace` must be enabled in order to receive trace data.
+* `type` (String) the type of event to start generating data for. Values of 'profiling', 'http', 'mongo', 'mysql', 'postgresql', 'memcached', 'mqtt', 'mqlight, 'redis', 'requests' and 'trace' are currently supported. As `trace` is added to request data, both `requests` and `trace` must be enabled in order to receive trace data.
 * `config` (Object) (optional) configuration map to be added for the data type being enabled. (see *[setConfig](#set-config)*) for more information.
 
 The following data types are disabled by default: `profiling`, `requests`, `trace`
 
 ### appmetrics.disable(`type`)
 Disable data generation of the specified data type.
-* `type` (String) the type of event to stop generating data for. Values of `profiling`, `http`, `mongo`, `mqlight`, `postgresql`, `mqtt`, `mysql`, `redis`, `requests` and `trace` are currently supported.
+* `type` (String) the type of event to stop generating data for. Values of `profiling`, `http`, `mongo`, `mqlight`, `postgresql`, `mqtt`, `mysql`, `redis`, `memcached`, `requests` and `trace` are currently supported.
 
 <a name="set-config"></a>
 ### appmetrics.setConfig(`type`, `config`)
@@ -280,6 +281,14 @@ Emitted when a Redis command is sent.
     * `time` (Number) the time in milliseconds when the MQLight event occurred. This can be converted to a Date using new Date(data.time).
     * `cmd` (String) the Redis command sent to the server or 'batch.exec'/'multi.exec' for groups of command sent using batch/multi calls.
     * `duration` (Number) the time taken in milliseconds.
+
+### Event: 'memcached'
+Emitted when a data is stored, retrieved or modified in Memcached using the `memcached` module.
+* `data` (Object) the data from the memcached event:
+    * `time` (Number) the milliseconds when the memcached event occurred. This can be converted to a Date using `new Date(data.time)`
+    * `method` (String) the method used in the memcached client, eg `set`, `get`, `append`, `delete`, etc.
+    * `key` (String) the key associated with the data.
+    * `duration` (Number) the time taken for the operation on the memcached data to occur.
 
 ### Event: 'request'
 Emitted when a request is made of the application that involves one or more monitored application level events. Request events are disabled by default.

--- a/probes/memcached-probe.js
+++ b/probes/memcached-probe.js
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright 2015 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+var Probe = require('../lib/probe.js');
+var aspect = require('../lib/aspect.js');
+var request = require('../lib/request.js');
+var util = require('util');
+var am = require('..');
+
+function MemcachedProbe() {
+	Probe.call(this, 'memcached');
+}
+util.inherits(MemcachedProbe, Probe);
+
+MemcachedProbe.prototype.attach = function(name, target) {
+	var that = this;
+	if( name != "memcached" ) return target;
+	target.__ddProbeAttached__ = true;
+
+	var methods = [
+	// args: key, callback
+	'get', 'gets', 'getMulti',
+	// args: key, value, lifetime, callback
+	'set', 'replace', 'add',
+	// args: key, value, lifetime, cas, callback
+	'cas',
+	// args: key, value, callback
+	'append', 'prepend',
+	// args: key, amount, callback
+	'increment', 'decrement', 'incr', 'decr',
+	// args: key, callback
+	'touch',
+	// args: key, lifetime, callback
+	'del', 'delete'
+	// args: callback
+	// 'version', 'flush', 'samples', 'slabs', 'items'
+	];
+
+	aspect.around(target.prototype, methods,
+		function(target, methodName, methodArgs, context) {
+			that.metricsProbeStart(context, methodName, methodArgs);
+			that.requestProbeStart(context, methodName, methodArgs);
+			aspect.aroundCallback(methodArgs, context,
+				function(target, callbackArgs, context) {
+					that.metricsProbeEnd(context, methodName, methodArgs);
+					that.requestProbeEnd(context, methodName, methodArgs);
+				}
+			);
+		}, function (target, methodName, methodArgs, context, rc) {
+			if (aspect.findCallbackArg(methodArgs) == undefined) {
+				that.metricsProbeEnd(context, methodName, methodArgs);
+				that.requestProbeEnd(context, methodName, methodArgs);
+			}
+			return rc;
+		}
+	);
+    return target;
+};
+
+/*
+ * Lightweight metrics probe for Memcached data store
+ * 
+ * These provide:
+ * 		time:		time event started
+ * 		method:		the API method/function being used
+ * 		key:		The data key being used
+ * 		duration:	the time for the request to respond
+ */
+MemcachedProbe.prototype.metricsEnd = function(context, method, methodArgs) {
+	context.timer.stop();
+	am.emit('memcached', {time: context.timer.startTimeMillis, method: method, key: methodArgs[0], duration: context.timer.timeDelta});
+};
+
+/*
+ * Heavyweight request probes for Memcached data store
+ */
+MemcachedProbe.prototype.requestStart = function (context, methodName, methodArgs) {
+	context.req = request.startRequest( 'Memcached', methodName, false, context.timer);
+};
+
+MemcachedProbe.prototype.requestEnd = function (context, methodName, methodArgs) {
+	context.req.stop({key: methodArgs[0]});
+};
+
+module.exports = MemcachedProbe;


### PR DESCRIPTION
This covers issue #38.

The probe currently only collects basic function/method and key information. It can be extended with further context data based if we receive requests for useful data to be added.