### PR TITLE
Add support for socket.io monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Node Application Metrics provides the following built-in data collection sources
  GC                 | Node/V8 garbage collection statistics
  Function profiling | Node/V8 function profiling (disabled by default)
  HTTP               | HTTP request calls made of the application
+ socket.io          | WebSocket data sent and received by the application
  MySQL              | MySQL queries made by the application
  MongoDB            | MongoDB queries made by the application
  PostgreSQL         | PostgreSQL queries made by the application
@@ -160,14 +161,14 @@ Stops the appmetrics monitoring agent. If the agent is not running this function
 
 ### appmetrics.enable(`type`, `config`)
 Enable data generation of the specified data type.
-* `type` (String) the type of event to start generating data for. Values of 'profiling', 'http', 'mongo', 'mysql', 'postgresql', 'memcached', 'mqtt', 'mqlight, 'redis', 'requests' and 'trace' are currently supported. As `trace` is added to request data, both `requests` and `trace` must be enabled in order to receive trace data.
+* `type` (String) the type of event to start generating data for. Values of 'profiling', 'http', 'mongo', 'mysql', 'socket.io', 'postgresql', 'memcached', 'mqtt', 'mqlight, 'redis', 'requests' and 'trace' are currently supported. As `trace` is added to request data, both `requests` and `trace` must be enabled in order to receive trace data.
 * `config` (Object) (optional) configuration map to be added for the data type being enabled. (see *[setConfig](#set-config)*) for more information.
 
 The following data types are disabled by default: `profiling`, `requests`, `trace`
 
 ### appmetrics.disable(`type`)
 Disable data generation of the specified data type.
-* `type` (String) the type of event to stop generating data for. Values of `profiling`, `http`, `mongo`, `mqlight`, `postgresql`, `mqtt`, `mysql`, `redis`, `memcached`, `requests` and `trace` are currently supported.
+* `type` (String) the type of event to stop generating data for. Values of `profiling`, `http`, `mongo`, `socket.io`, `mqlight`, `postgresql`, `mqtt`, `mysql`, `redis`, `memcached`, `requests` and `trace` are currently supported.
 
 <a name="set-config"></a>
 ### appmetrics.setConfig(`type`, `config`)
@@ -240,6 +241,14 @@ Emitted when a HTTP request is made of the application.
     * `method` (String) the HTTP method used for the request.
     * `url` (String) the URL on which the request was made.
     * `duration` (Number) the time taken for the HTTP request to be responded to in ms.
+    
+### Event: 'socket.io'
+Emitted when WebSocket data is sent or received by the application using socket.io.
+* `data` (Object) the data from the socket.io request:
+    * `time` (Number) the milliseconds when the event occurred. This can be converted to a Date using `new Date(data.time)`.
+    * `method` (String) whether the event is a `broadcast` or `emit` from the application, or a `receive` from a client  .
+    * `event` (String) the name used for the event.
+    * `duration` (Number) the time taken for event to be sent or for a received event to be handled.
 
 ### Event: 'mysql'
 Emitted when a MySQL query is made using the `mysql` module.

--- a/probes/socketio-probe.js
+++ b/probes/socketio-probe.js
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright 2015 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+var Probe = require('../lib/probe.js');
+var aspect = require('../lib/aspect.js');
+var request = require('../lib/request.js');
+var util = require('util');
+var am = require('..');
+
+function SocketioProbe() {
+	Probe.call(this, 'socket.io');
+}
+util.inherits(SocketioProbe, Probe);
+
+SocketioProbe.prototype.attach = function(name, target) {
+	var that = this;
+	if( name != "socket.io" ) return target;
+	target.__ddProbeAttached__ = true;
+
+	/*
+	 * Patch io.sockets.emit() calls to broadcast to clients
+	 */
+	var newtarget = aspect.afterConstructor(target, {},
+		function(target, methodName, methodArgs, context, server) {
+			var broadcast = 'broadcast';
+			aspect.around(server.sockets, 'emit',
+				function(target, methodName, methodArgs, context){
+					that.metricsProbeStart(context, broadcast, methodArgs);
+					that.requestProbeStart(context, broadcast, methodArgs);
+				},
+				function(target, methodName, methodArgs, context, rc){
+					that.metricsProbeEnd(context, broadcast, methodArgs);
+					that.requestProbeEnd(context, broadcast, methodArgs);
+				}
+			);
+			return server;
+		}
+	)
+
+	/*
+	 * Patch io.emit() calls to broadcast to clients
+	 */
+	var broadcast = 'broadcast';
+	aspect.around(target.prototype, 'emit',
+		function(target, methodName, methodArgs, context){
+			that.metricsProbeStart(context, broadcast, methodArgs);
+			that.requestProbeStart(context, broadcast, methodArgs);
+		},
+		function(target, methodName, methodArgs, context, rc){
+			that.metricsProbeEnd(context, broadcast, methodArgs);
+			that.requestProbeEnd(context, broadcast, methodArgs);
+		}
+	);
+	
+	aspect.before(target.prototype, ['on', 'addListener'],
+			function(target, methodName, methodArgs, context) {
+			if(methodArgs[0] !== 'connection') return;
+			if (aspect.findCallbackArg(methodArgs) != undefined) {
+				aspect.aroundCallback(methodArgs, context, function(target, methodArgs, context) {
+					var socket = methodArgs[0];
+					/*
+					 * Patch Socket#emit() calls
+					 */
+					aspect.around(socket, 'emit',
+						function(target, methodName, methodArgs, context){
+							that.metricsProbeStart(context, methodName, methodArgs);
+							that.requestProbeStart(context, methodName, methodArgs);
+						},
+						function(target, methodName, methodArgs, context, rc){
+							that.metricsProbeEnd(context, methodName, methodArgs);
+							that.requestProbeEnd(context, methodName, methodArgs);
+							return rc;
+						}
+					);
+					/*
+					 * Patch socket.on incoming events
+					 */
+					var receive = 'receive';
+					aspect.before(socket, ['on', 'addListener'],
+						function(target, methodName, methodArgs, context) {
+							aspect.aroundCallback(methodArgs, context,
+								function(target, callbackArgs, context){
+									that.metricsProbeStart(context, receive, methodArgs);
+									that.requestProbeStart(context, receive, methodArgs);
+								}, 
+								function (target, callbackArgs, context, rc) {
+									that.metricsProbeEnd(context, receive, methodArgs);
+									that.requestProbeEnd(context, receive, methodArgs);
+									return rc;
+								}
+							);
+						}
+					);
+				}
+			);
+		}
+	});
+	return newtarget;
+};
+
+/*
+ * Lightweight metrics probe for Socket.io websocket connections
+ * 
+ * These provide:
+ * 		time:		time event started
+ * 		method:		the type of socket.io action
+ * 		event:		the event broadcast/emitted/received
+ * 		duration:	the time for the action to complete
+ */
+SocketioProbe.prototype.metricsEnd = function(context, methodName, methodArgs) {
+	context.timer.stop();
+	am.emit('socket.io', {time: context.timer.startTimeMillis, method: methodName, event: methodArgs[0], duration: context.timer.timeDelta});
+};
+
+/*
+ * Heavyweight request probes for Socket.io websocket connections
+ */
+SocketioProbe.prototype.requestStart = function (context, methodName, methodArgs) {
+	/* 
+	 * method names are "broadcast", "receive" and "emit"
+	 */
+	if (methodName !== 'receive') {
+		context.req = request.startRequest('socket.io', methodName, false, context.timer);
+	} else {
+		context.req = request.startRequest('socket.io', methodName, true, context.timer);
+	}
+};
+
+SocketioProbe.prototype.requestEnd = function (context, methodName, methodArgs) {
+	context.req.stop({method: methodName, event: methodArgs[0]});
+};
+
+module.exports = SocketioProbe;


### PR DESCRIPTION
This is the implementation for issue #84.

The code instruments the following functions as direct prototypes of the socket.io module:
`io.emit()`
`io.on()`
`io.addListener()`
and the following function by instrumenting the `sockets` field in the constructed `io` object:
`io.sockets.emit()`

The last one relies on the new `aspects.afterConstructor()` API.