### PR TITLE
Carry out probe attached check centrally

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,15 +56,19 @@ files.forEach(function (fileName) {
 var data = {};
 
 aspect.after(module.__proto__, 'require', data, function(obj, methodName, args, context, ret) {
-	for (var i = 0; i < probes.length; i++) {
-		if (probes[i].name === args[0]) {
-			ret = probes[i].attach(args[0], ret, module.exports);
+	if (ret.__ddProbeAttached__) {
+		return ret;
+	} else {
+		for (var i = 0; i < probes.length; i++) {
+			if (probes[i].name === args[0]) {
+				ret = probes[i].attach(args[0], ret, module.exports);
+			}
+			if (probes[i].name === 'trace') {
+				ret = probes[i].attach(args[0], ret);
+			}
 		}
-		if (probes[i].name === 'trace') {
-			ret = probes[i].attach(args[0], ret);
-		}
+		return ret;
 	}
-	return ret;
 });
 
 /*

--- a/lib/aspect.js
+++ b/lib/aspect.js
@@ -111,6 +111,11 @@ exports.afterConstructor = function (target, context, hookAfter) {
 			var ret = target.apply(null, arguments);
 			return hookAfter(this, '()', arguments, context, ret);
 		};
+		for (var property in target) {
+			if (target.hasOwnProperty(property)){
+				newFunc[property] = target[property];
+			}
+		}
 		newFunc.prototype = target.prototype;
 		newFunc.exports = target.exports;
 		return newFunc;


### PR DESCRIPTION
This is the PR for issue #96 

It moves the check for `__ddProbeAttached__` into index.js were we run the probes against the modules as their required.

Modules that return constructors are a special case. As the socket.io probe does that, there's been some fixup to that probe. The socket.io probe doesn't set `__ddProbeAttached__` to ensure that the constructor is probed each time, and the probes to the module prototypes are wrapped in a module specific `__prototypeProbeAttached__` check to make sure those are only probed once.