### PR TITLE
Added leveldown probe to monitor basic LevelDB operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Node Application Metrics provides the following built-in data collection sources
  Function profiling | Node/V8 function profiling (disabled by default)
  HTTP               | HTTP request calls made of the application
  socket.io          | WebSocket data sent and received by the application
+ LevelDB          	| LevelDB queries made by the application
  MySQL              | MySQL queries made by the application
  MongoDB            | MongoDB queries made by the application
  PostgreSQL         | PostgreSQL queries made by the application
@@ -284,6 +285,17 @@ Emitted when a MQLight message is sent or received.
     * `qos` (Number) the QoS level for a 'send' call, undefined if not set.
     * `duration` (Number) the time taken in milliseconds.
 
+### Event: 'leveldown'
+Emitted when a LevelDB query is made using the `leveldown` module.
+* `data` (Object) the data from the LevelDB query:
+    * `time` (Number) the time in milliseconds when the LevelDB query was made. This can be converted to a Date using `new Date(data.time)`.
+    * `method` (String) The leveldown method being used.
+	* `key` (Object) The key being used for a call to `get`, `put` or `del` (Undefined for other methods)
+	* `value` (Object) The value being added to the LevelDB database using the `put` method (Undefined for other methods) 
+	* `opCount` (Number) The number of operations carried out by a `batch` method (Undefined for other methods) 
+    * `duration` (Number) the time taken for the LevelDB query to be responded to in ms.
+	
+	
 ### Event: 'redis'
 Emitted when a Redis command is sent.
 * `data` (Object) the data from the Redis event:

--- a/probes/leveldown-probe.js
+++ b/probes/leveldown-probe.js
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright 2015 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+ 
+var Probe = require('../lib/probe.js');
+var aspect = require('../lib/aspect.js');
+var request = require('../lib/request.js');
+var am = require('appmetrics');
+var util = require('util');
+
+function LeveldownProbe(){
+	Probe.call(this, 'leveldown');
+}
+util.inherits(LeveldownProbe, Probe);
+
+function aspectLvldownMethod(dbTarget, methods, probe){
+	aspect.before(dbTarget, methods, function(dbTarget, methodName, methodArgs, probeData){
+		probe.metricsProbeStart(probeData, dbTarget, methodName, methodArgs);
+		probe.requestProbeStart(probeData, dbTarget, methodName, methodArgs);
+		if (aspect.findCallbackArg(methodArgs) != undefined){
+			aspect.aroundCallback(methodArgs, probeData, function(dbTarget, args, probeData){
+				probe.metricsProbeEnd(probeData, methodName, methodArgs);
+				probe.requestProbeEnd(probeData, methodName, methodArgs);
+			});
+		}
+	})	
+}
+
+//Attaches probe to module
+LeveldownProbe.prototype.attach = function(name, target){	
+	var that = this;	//Referencing probe
+	var methods = ['put', 'get', 'del', 'batch']; //Monitored leveldown methods
+	if (name != 'leveldown') return target;
+	if(target.__ddProbeAttached__) return target;
+
+	
+	//Wrapping the target in new function as leveldown returns constructor
+	var newTarget = function() {
+		var lvldownObj = target.apply(null, arguments);
+		lvldownObj._ddProbeAttached_=true;
+		aspect.after(lvldownObj, 'open', {}, function(dbTarget, methodName, args, probeData,rc){
+			aspectLvldownMethod(dbTarget, methods, that);
+		})
+		return lvldownObj;
+	};
+	return newTarget;
+}
+
+/*
+ * Lightweight metrics probe for leveldown queries
+ * 
+ * These provide:
+ * 		time:		time event started
+ * 		method: 	leveldown method being executed
+ *		key:		The key being used for a call to `get`, `put` or `del` 
+ *		value: 		The value being added to the LevelDB database using `put`
+ *		opCount: 	The number of operations being performed by `batch`
+ *		duration: 	The time taken for the LevelDB query to respond in ms
+ *		
+ *		Note: key, value and opCount are undefined for methods other than those *		stated
+ */
+ 
+ 
+LeveldownProbe.prototype.metricsEnd = function(probeData, method, methodArgs) {
+	probeData.timer.stop();
+	if (method == 'put'){
+		am.emit('leveldown', {time: probeData.timer.startTimeMillis, method: method, key: methodArgs[0], value: methodArgs[1], duration: probeData.timer.timeDelta});
+	}
+	else if (method == 'del' || method == 'get'){
+		am.emit('leveldown', {time: probeData.timer.startTimeMillis, method: method, key: methodArgs[0], duration: probeData.timer.timeDelta});
+	}
+	else if(method == 'batch'){
+		am.emit('leveldown', {time: probeData.timer.startTimeMillis, method: method, opCount: methodArgs[0].length, duration: probeData.timer.timeDelta});
+	}
+};
+
+/*
+ * Heavyweight request probes for leveldown queries
+ */
+LeveldownProbe.prototype.requestStart = function (probeData, dbTarget, method, methodArgs) {
+	 req = request.startRequest( 'DB', "query" );
+	 req.setContext({leveldown: methodArgs[0]});
+};
+
+LeveldownProbe.prototype.requestEnd = function (probeData, method, methodArgs) {
+	req.stop({leveldown: methodArgs[0]});
+};
+
+module.exports = LeveldownProbe;


### PR DESCRIPTION
This is the implementation of issue #67 

The probe instruments the following leveldown functions:

`leveldown.put()`
`leveldown.get()`
`leveldown.del()`
`leveldown.batch()`