### PR TITLE
Add support for event loop latency monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Node Application Metrics provides the following built-in data collection sources
  CPU                | Process and system CPU
  Memory             | Process and system memory usage
  GC                 | Node/V8 garbage collection statistics
+ Event Loop         | Event loop latency information
  Function profiling | Node/V8 function profiling (disabled by default)
  HTTP               | HTTP request calls made of the application
  socket.io          | WebSocket data sent and received by the application
@@ -162,14 +163,14 @@ Stops the appmetrics monitoring agent. If the agent is not running this function
 
 ### appmetrics.enable(`type`, `config`)
 Enable data generation of the specified data type.
-* `type` (String) the type of event to start generating data for. Values of `profiling`, `http`, `mongo`, `socket.io`, `mqlight`, `postgresql`, `mqtt`, `mysql`, `redis`, `memcached`, `requests` and `trace` are currently supported. As `trace` is added to request data, both `requests` and `trace` must be enabled in order to receive trace data.
+* `type` (String) the type of event to start generating data for. Values of `eventloop`, `profiling`, `http`, `mongo`, `socket.io`, `mqlight`, `postgresql`, `mqtt`, `mysql`, `redis`, `memcached`, `requests` and `trace` are currently supported. As `trace` is added to request data, both `requests` and `trace` must be enabled in order to receive trace data.
 * `config` (Object) (optional) configuration map to be added for the data type being enabled. (see *[setConfig](#set-config)*) for more information.
 
 The following data types are disabled by default: `profiling`, `requests`, `trace`
 
 ### appmetrics.disable(`type`)
 Disable data generation of the specified data type.
-* `type` (String) the type of event to stop generating data for. Values of `profiling`, `http`, `mongo`, `socket.io`, `mqlight`, `postgresql`, `mqtt`, `mysql`, `redis`, `memcached`, `requests` and `trace` are currently supported.
+* `type` (String) the type of event to stop generating data for. Values of `eventloop`, `profiling`, `http`, `mongo`, `socket.io`, `mqlight`, `postgresql`, `mqtt`, `mysql`, `redis`, `memcached`, `requests` and `trace` are currently supported.
 
 <a name="set-config"></a>
 ### appmetrics.setConfig(`type`, `config`)
@@ -222,6 +223,14 @@ Emitted when a garbage collection (GC) cycle occurs in the underlying V8 runtime
     * `size` (Number) the size of the JavaScript heap in bytes.
     * `used` (Number) the amount of memory used on the JavaScript heap in bytes.
     * `duration` (Number) the duration of the GC cycle in milliseconds.
+
+### Event: 'eventloop'
+Emitted every 5 seconds, summarising sample based information of the event loop latency
+* `data` (Object) the data from the event loop sample:
+    * `time` (Number) the milliseconds when the event was emitted. This can be converted to a Date using `new Date(data.time)`.
+    * `latency.min` (Number) the shortest sampled latency, in milliseconds.
+    * `latency.max` (Number) the longest sampled latency, in milliseconds.
+    * `latency.avg` (Number) the average sampled latency, in milliseconds.
 
 ### Event: 'profiling'
 Emitted when a profiling sample is available from the underlying V8 runtime.


### PR DESCRIPTION
This PR covers issue #72 to add event loop latency data.

### Implementation

This adds basic event loop latency monitoring. Its added into index.js, which is non-ideal and should eventually be moved into its own file. 

The monitoring works on a simplistic process of spawning a `latencyCheck` loop which is run every `latencyCheckInteval` using `setInterval`. The interval is currently 500ms, and isn't configurable - that should be added via the `setConfig` API.

The latencyCheck loop works by calling `setImmediate` and looking at the latency between the `setImmediate` call being made and its function being executed. This measures the latency at the exact point that the latencyCheck loop ran. This does however have some limitations (see below).

A second `latencyReport` loop is then run event `latencyReportInteval` using `setInterval`. The interval is currently 5000ms, and isn't configurable - that should be added via the `setConfig` API.
The report look raises the `eventloop` event, and clears out the counters that it is updating, so that we start a new sampling period.

### Limitations
If there are long running/blocking events, the latencyCheck loop itself will be blocked until the long event finishes. Once it does, there may be no other pending invents. In this scenario there will appear to be no event latency even though there was a long running, blocking event. This isn't an issue if long running events occur back-to-back as they will occur between the `latencyCheck` and the `setImmediate` callback.

The net is, if this becomes a problem and we are unable to detect where the application is performing badly due to being 100% utilitzed, we should look at an alternative approach, such as using `setTimeout()` instead of `setImmediate()`, which widens the window for other events to cause latency when we're sampling.