### PR TITLE
Change event name for socket.io to 'socketio'

### DIFF
--- a/probes/socketio-probe.js
+++ b/probes/socketio-probe.js
@@ -119,7 +119,7 @@ SocketioProbe.prototype.attach = function(name, target) {
  */
 SocketioProbe.prototype.metricsEnd = function(context, methodName, methodArgs) {
 	context.timer.stop();
-	am.emit('socket.io', {time: context.timer.startTimeMillis, method: methodName, event: methodArgs[0], duration: context.timer.timeDelta});
+	am.emit('socketio', {time: context.timer.startTimeMillis, method: methodName, event: methodArgs[0], duration: context.timer.timeDelta});
 };
 
 /*
@@ -130,9 +130,9 @@ SocketioProbe.prototype.requestStart = function (context, methodName, methodArgs
 	 * method names are "broadcast", "receive" and "emit"
 	 */
 	if (methodName !== 'receive') {
-		context.req = request.startRequest('socket.io', methodName, false, context.timer);
+		context.req = request.startRequest('socketio', methodName, false, context.timer);
 	} else {
-		context.req = request.startRequest('socket.io', methodName, true, context.timer);
+		context.req = request.startRequest('socketio', methodName, true, context.timer);
 	}
 };
 


### PR DESCRIPTION
This is for issue #101 and changes the name emitted for `socket.io` monitoring to `socketio` (removing the dot).

This doesn't include the README.md update as it conflicts with the other open PR.

@tobespc when you review/merged this, can you create your own PR to update the README.md?