### PR TITLE
Add missing return from callback.

### DIFF
--- a/probes/trace-probe.js
+++ b/probes/trace-probe.js
@@ -129,7 +129,7 @@ if(lastMethodArg == '') lastMethodArg = 'undefined';
                 var cb = arguments[arguments.length-1];
                 arguments[arguments.length-1] = function() {
                     req.stop(cxtFunc());
-                    cb.apply(this, arguments);
+                    return cb.apply(this, arguments);
                 }
             }
         }


### PR DESCRIPTION
One of the cases where a call back function is wrapped by trace was missing a return statement.
This fixes issue #87 - cannot enable('trace') for ghost v0.7.1 application