### PR TITLE
Add support for com.ibm.diagnostics.healthcenter.probes.transmit

### DIFF
--- a/appmetrics.properties
+++ b/appmetrics.properties
@@ -19,4 +19,4 @@ com.ibm.diagnostics.healthcenter.data.profiling=off
 
 # Allow probes to transmit data to the client: true | false
 # Defaults to false - probe data not sent.
-#com.ibm.diagnostics.healthcenter.probes.transmit=false
+#appmetrics.probes.transmit=false

--- a/appmetrics.properties
+++ b/appmetrics.properties
@@ -16,3 +16,7 @@ com.ibm.diagnostics.healthcenter.logging.plugins=info
 
 # Start with method profiling enabled/disabled: on | off
 com.ibm.diagnostics.healthcenter.data.profiling=off
+
+# Allow probes to transmit data to the client: true | false
+# Defaults to false - probe data not sent.
+#com.ibm.diagnostics.healthcenter.probes.transmit=false

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ agent.start();
 
 var hcAPI = require("./appmetrics-api.js");
 
-// This is set by the property com.ibm.diagnostics.healthcenter.probes.transmit
+// This is set by the property appmetrics.probes.transmit
 // at startup. Cache the value so we only make one native call.
 var transmitData = agent.nativeEmitCheck();
 
@@ -230,7 +230,7 @@ module.exports.emit = function (topic, data) {
 		this.api.raiseLocalEvent(topic, data);
 	}
 	// Send data to any out of process connection.
-	// Controlled by the property com.ibm.diagnostics.healthcenter.probes.transmit
+	// Controlled by the property appmetrics.probes.transmit
 	if( transmitData ) {
 		data = serializer.serialize(data);
 		agent.nativeEmit(topic, String(data));

--- a/src/appmetrics.cpp
+++ b/src/appmetrics.cpp
@@ -242,7 +242,7 @@ static bool initMonitorApi() {
 	monitorApi::sendControl = (void (*)(std::string&, unsigned int, void*)) getMonitorApiFunction(pluginPath, std::string("sendControl"));
 	monitorApi::registerListener = (void (*)(void (*func)(const std::string&, unsigned int, void*))) getMonitorApiFunction(pluginPath, std::string("registerListener"));
 
-	std::string transmitStr = loaderApi->getProperty("com.ibm.diagnostics.healthcenter.probes.transmit");
+	std::string transmitStr = loaderApi->getProperty("appmetrics.probes.transmit");
 	if( "true" == transmitStr ) {
 		doNativeEmit = true;
 	}

--- a/src/appmetrics.cpp
+++ b/src/appmetrics.cpp
@@ -41,6 +41,7 @@ using namespace ibmras::common::logging;
 static std::string* applicationDir;
 static std::string* appmetricsDir;
 static bool running = false;
+static bool doNativeEmit = false;
 static loaderCoreFunctions* loaderApi;
 
 #define PROPERTIES_FILE "appmetrics.properties"
@@ -241,6 +242,11 @@ static bool initMonitorApi() {
 	monitorApi::sendControl = (void (*)(std::string&, unsigned int, void*)) getMonitorApiFunction(pluginPath, std::string("sendControl"));
 	monitorApi::registerListener = (void (*)(void (*func)(const std::string&, unsigned int, void*))) getMonitorApiFunction(pluginPath, std::string("registerListener"));
 
+	std::string transmitStr = loaderApi->getProperty("com.ibm.diagnostics.healthcenter.probes.transmit");
+	if( "true" == transmitStr ) {
+		doNativeEmit = true;
+	}
+
 	return isMonitorApiValid();
 }
 
@@ -360,6 +366,10 @@ static void sendData(const std::string &sourceId, unsigned int size, void *data)
 
 	async->data = payload;
 	uv_async_send(async);
+}
+
+NAN_METHOD(nativeEmitCheck) {
+	info.GetReturnValue().Set(doNativeEmit);
 }
 
 NAN_METHOD(nativeEmit) {
@@ -545,6 +555,7 @@ void init(Handle<Object> exports, Handle<Object> module) {
 	exports->Set(Nan::New<String>("stop").ToLocalChecked(), Nan::New<FunctionTemplate>(stop)->GetFunction());
 	exports->Set(Nan::New<String>("localConnect").ToLocalChecked(), Nan::New<FunctionTemplate>(localConnect)->GetFunction());
 	exports->Set(Nan::New<String>("nativeEmit").ToLocalChecked(), Nan::New<FunctionTemplate>(nativeEmit)->GetFunction());
+	exports->Set(Nan::New<String>("nativeEmitCheck").ToLocalChecked(), Nan::New<FunctionTemplate>(nativeEmitCheck)->GetFunction());
 	exports->Set(Nan::New<String>("sendControlCommand").ToLocalChecked(), Nan::New<FunctionTemplate>(sendControlCommand)->GetFunction());
 
 	/*


### PR DESCRIPTION
This patch adds a new property to the appmetrics.properties file com.ibm.diagnostics.healthcenter.probes.transmit which can be true or false.
If set to true probe data will be sent to the monitoring client.
If set to false the data will not be sent. false is the default.

I have added a new native method (nativeEmitCheck) that reports whether data should be transmitted. This property is checked at startup and it's value cached and the native method is only called once, at start up, with the true/false value then stored in index.js. This prevents repeated calls from Javascript to native code.

In the future the property could be extended to be a comma separated list of probes to send data for. (With true enabling all probes as now and false disabling all probes.) Changing this would not break users who wanted to continue setting true or false.
nativeEmitCheck() could be extended to take a probe name and return whether that probe was enabled. (If neccessary the no-args form could still report whether all probes were globally enabled or not.) nativeEmitCheck() is not part of the public API so could be safely changed or replaced if necessary.

This is for issue #110