### PR TITLE
Map listen API to instrumented constructor

### DIFF
--- a/probes/socketio-probe.js
+++ b/probes/socketio-probe.js
@@ -52,7 +52,11 @@ SocketioProbe.prototype.attach = function(name, target) {
 			);
 			return server;
 		}
-	)
+	);
+	/*
+	 * Remap the listen API to point to new constructor
+	 */
+	newtarget.listen = newtarget;
 
 	/* 
 	 * We patch the constructor every time, but only want to patch prototype


### PR DESCRIPTION
This is for issue #114 . This remaps the listen API to point to the instrumented constructor rather than leaving it to point at the original, un-instrumented version.