### PR TITLE
Allow CPU profiling to be emitted in v8 profiling format

### DIFF
--- a/appmetrics-api.js
+++ b/appmetrics-api.js
@@ -145,19 +145,31 @@ function API(agent, appmetrics) {
     };
 
 	var formatProfiling = function (message) {
-		var lines = message.trim().split('\n');
-		var prof = {
-			date: 0,
-			functions: [],
-		};
-		lines.forEach(function (line) {
-			var values = line.split(',');
-			if (values[1] == 'Node') {
-				prof.functions.push({self: parseInt(values[2]), parent: parseInt(values[3]), file: values[4], name: values[5], line: parseInt(values[6]), count: parseInt(values[7])});
-			} else if (values[1] == 'Start') {
-				prof.time = parseInt(values[2]);
-			}
-		});
+		
+		var prof;
+		
+		//Message may already be in JSON format
+		if (message[0] == "{"){
+			prof = JSON.parse(message);
+		}
+		
+		//If not, format it
+		else {
+			prof = {
+				date: 0,
+				functions: [],
+			};
+			
+			var lines = message.trim().split('\n');
+			lines.forEach(function (line) {
+				var values = line.split(',');
+				if (values[1] == 'Node') {
+					prof.functions.push({self: parseInt(values[2]), parent: parseInt(values[3]), file: values[4], name: values[5], line: parseInt(values[6]), count: parseInt(values[7])});
+				} else if (values[1] == 'Start') {
+					prof.time = parseInt(values[2]);
+				}
+			});
+		}
 	 	that.emit('profiling', prof);	
 	};
 

--- a/src/objecttracker.cpp
+++ b/src/objecttracker.cpp
@@ -18,6 +18,7 @@
 #define BUILDING_NODE_EXTENSION
 #endif
 
+#include "node.h"
 #include "v8.h"
 #include "v8-profiler.h"
 #include "nan.h"
@@ -36,7 +37,27 @@ NAN_METHOD(getObjectHistogram) {
 
 	HeapProfiler *heapProfiler = isolate->GetHeapProfiler();
 
-	const HeapSnapshot* snapshot = heapProfiler->TakeHeapSnapshot();
+	
+#if NODE_VERSION_AT_LEAST(4, 0, 0) // > v0.11+
+	// Title field removed in Node 4.x
+#else
+	Local<String> snapshotName = String::NewFromUtf8(isolate, "snapshot");
+#endif
+
+	/* TakeHeapSnapshot used to be called TakeSnapshot
+	 * It's arguments changed so the latest versions don't need a title param.
+	 */
+#if NODE_VERSION_AT_LEAST(0, 11, 0) // > v0.11+
+	const HeapSnapshot* snapshot = heapProfiler->TakeHeapSnapshot(
+#else
+	const HeapSnapshot* snapshot = heapProfiler->TakeSnapshot(snapshotName);
+#endif
+#if NODE_VERSION_AT_LEAST(4, 0, 0) // > v0.11+
+	// Title field removed in Node 4.x
+#else
+	snapshotName
+#endif
+	);
 
 	/* Build a simple histogram from the heap snapshot. */
 	Local<Object> histogram = Object::New(isolate);


### PR DESCRIPTION
Added functionality to change the format of CPU profiling data between V8 profiling and the format appmetrics usually produces.

Profiling data produced when in v8 mode will be emitted in 60 second intervals while regular data is made available every 5 seconds. 