### PR TITLE
Fix accidental removal of objecttracker.cpp from sources list.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -59,6 +59,7 @@
       "target_name": "appmetrics",
       "sources": [
         "<(INTERMEDIATE_DIR)/appmetrics.cpp",
+        "<(srcdir)/objecttracker.cpp",
       ],
       'variables': {
         'appmetricslevel%':'<(appmetricsversion)<(build_id)',


### PR DESCRIPTION
npm installs but cannot run due to missing symbol.