### PR TITLE
Fixed issue with instrumenting leveldown on multiple 'open' calls

### DIFF
--- a/probes/leveldown-probe.js
+++ b/probes/leveldown-probe.js
@@ -50,9 +50,7 @@ LeveldownProbe.prototype.attach = function(name, target){
 	var newTarget = function() {
 		var lvldownObj = target.apply(null, arguments);
 		lvldownObj._ddProbeAttached_=true;
-		aspect.after(lvldownObj, 'open', {}, function(dbTarget, methodName, args, probeData,rc){
-			aspectLvldownMethod(dbTarget, methods, that);
-		})
+		aspectLvldownMethod(dbTarget, methods, that);
 		return lvldownObj;
 	};
 	return newTarget;


### PR DESCRIPTION
Previously we were instrumenting the leveldown object after each call to open, causing more events to be emitted than we needed. Fixed to only instrument the leveldown object once