### PR TITLE
Move calls to uv_async_init so they occur on the main thread.

### DIFF
--- a/src/appmetrics.cpp
+++ b/src/appmetrics.cpp
@@ -389,8 +389,7 @@ static void sendData(const std::string &sourceId, unsigned int size, void *data)
 	 */
 	void* dataCopy = malloc(size);
 	payload->source = new std::string(sourceId);
-	uv_async_t *async = new uv_async_t;
-	if ( NULL == dataCopy || NULL == payload->source || NULL == async ) {
+	if ( NULL == dataCopy || NULL == payload->source ) {
 		freePayload(payload);
 		return;
 	}

--- a/src/appmetrics.cpp
+++ b/src/appmetrics.cpp
@@ -43,6 +43,25 @@ static std::string* appmetricsDir;
 static bool running = false;
 static loaderCoreFunctions* loaderApi;
 
+struct MessageData {
+	const std::string* source;
+	void* data;
+	unsigned int size;
+	MessageData* next;
+};
+
+static MessageData* messageList = NULL;
+static uv_mutex_t _messageListMutex;
+static uv_mutex_t* messageListMutex = &_messageListMutex;
+static uv_async_t _messageAsync;
+static uv_async_t *messageAsync = &_messageAsync;
+
+struct Listener {
+	Nan::Callback *callback;
+};
+
+Listener* listener;
+
 #define PROPERTIES_FILE "appmetrics.properties"
 #define APPMETRICS_VERSION "99.99.99.29991231"
 
@@ -297,21 +316,6 @@ NAN_METHOD(spath) {
 
 }
 
-struct MessageData {
-	const std::string* source;
-	void* data;
-	unsigned int size;
-};
-
-struct Listener {
-	Nan::Callback *callback;
-};
-
-
-Listener* listener;
-
-
-
 static void freePayload(MessageData* payload) {
 
 	/* Clear fields to guard against the same payload being freed twice. */
@@ -326,44 +330,49 @@ static void freePayload(MessageData* payload) {
 		delete payload->source;
 		payload->source = NULL;
 	}
+	payload->next = NULL;
 	delete payload;
-}
-
-static void cleanupData(uv_handle_t *handle) {
-
-	if( NULL != handle ) {
-		MessageData* payload = static_cast<MessageData*>(handle->data);
-		/* Guard against being called twice. */
-		handle->data = NULL;
-		freePayload(payload);
-	}
-	delete handle;
-
 }
 
 static void emitMessage(uv_async_t *handle, int status) {
 	Nan::HandleScope scope;
-	MessageData* payload = static_cast<MessageData*>(handle->data);
 
-	TryCatch try_catch;
-	const unsigned argc = 2;
-	Local<Value> argv[argc];
-	const char * source = (*payload->source).c_str();
+	// The event loop may coalesce multiple sends so the
+	// emitMessage function needs to clear the entire queue.
+	// Take the head of the queue and save it and mark the
+	// queue as NULL to hold the lock for as short a time as
+	// possible.
 
-	Local<Object> buffer = Nan::CopyBuffer((char*)payload->data, payload->size).ToLocalChecked();
-	argv[0] = Nan::New<String>(source).ToLocalChecked();
-	argv[1] = buffer;
+	uv_mutex_lock(messageListMutex);
 
-	listener->callback->Call(argc, argv);
-	if (try_catch.HasCaught()) {
+	MessageData* currentMessage = messageList;
+	messageList = NULL;
+
+	uv_mutex_unlock(messageListMutex);
+
+	while(currentMessage != NULL ) {
+		TryCatch try_catch;
+		const unsigned argc = 2;
+		Local<Value> argv[argc];
+		const char * source = (*currentMessage->source).c_str();
+
+		Local<Object> buffer = Nan::CopyBuffer((char*)currentMessage->data, currentMessage->size).ToLocalChecked();
+		argv[0] = Nan::New<String>(source).ToLocalChecked();
+		argv[1] = buffer;
+
+		listener->callback->Call(argc, argv);
+		if (try_catch.HasCaught()) {
 #if NODE_VERSION_AT_LEAST(0, 11, 0) // > v0.11+
-		node::FatalException(v8::Isolate::GetCurrent(), try_catch);
+			node::FatalException(v8::Isolate::GetCurrent(), try_catch);
 #else
-	node::FatalException(try_catch);
+			node::FatalException(try_catch);
 #endif
-
+		}
+		MessageData* nextMessage = currentMessage->next;
+		freePayload(currentMessage);
+		currentMessage = nextMessage;
 	}
-	uv_close((uv_handle_t*) handle, cleanupData);
+
 }
 
 static void sendData(const std::string &sourceId, unsigned int size, void *data) {
@@ -388,10 +397,22 @@ static void sendData(const std::string &sourceId, unsigned int size, void *data)
 	memcpy(dataCopy, data, size);
 	payload->data = dataCopy;
 	payload->size = size;
+	payload->next = NULL;
 
-	async->data = payload;
-	uv_async_init(uv_default_loop(), async, (uv_async_cb)emitMessage);
-	uv_async_send(async);
+	// Put the next message on the end of the queue.
+	// (So they are sent in the same order we added them.)
+	uv_mutex_lock(messageListMutex);
+	MessageData** tail = &messageList;
+	while( *tail != NULL ) {
+		tail = &((*tail)->next);
+	}
+	(*tail) = payload;
+	uv_mutex_unlock(messageListMutex);
+
+	// Notify the event loop that there is a new message.
+	// The event loop may coalesce multiple sends so the
+	// emitMessage function needs to clear the entire queue.
+	uv_async_send(messageAsync);
 }
 
 NAN_METHOD(nativeEmit) {
@@ -568,6 +589,13 @@ void init(Handle<Object> exports, Handle<Object> module) {
 		Nan::ThrowError("Conflicting appmetrics module was already loaded by node-hc. Try running with node instead.");
 		return;
 	}
+
+	// Setup global data mutex
+	uv_mutex_init(messageListMutex);
+
+	// Setup message sending callback and sure it does not keep us alive.
+	uv_async_init(uv_default_loop(), messageAsync, (uv_async_cb)emitMessage);
+	uv_unref((uv_handle_t*) messageAsync);
 
 	/*
 	 * Set exported functions


### PR DESCRIPTION
This patch moves all our calls to uv_async_init back onto the main thread.
That also means changing how we pass our messages to the event loop as we can no longer put them in the data field of the uv_async_t structure.
I've added a linked list to store the messages to send and some simple locking to make sure the two threads don't interfere with one another. We need to use the list as the libuv docs say that two sends of the same callback may be coalesced. See: http://docs.libuv.org/en/v1.x/async.html?highlight=uv_async_send#c.uv_async_send
In practise this just means that when we receive the event we deal with all the messages that are on the list not just the latest one.