### PR TITLE
Fix npm test failure on dev versions

### DIFF
--- a/tests/general_tests.js
+++ b/tests/general_tests.js
@@ -278,9 +278,9 @@ function runNodeEnvTests(nodeEnvData)
 
   if (nodeEnvData['appmetrics.version'])
   {
-    assert(/^\d+\.\d+\.\d+\.\d{12}$/.test(nodeEnvData['appmetrics.version']),
+    assert(/^\d+\.\d+\.\d+(-dev\.\d+)?\.\d{12}$/.test(nodeEnvData['appmetrics.version']),
            "Appmetrics version format not recognised"
-            + nodeEnvData['appmetrics.version'] + ", expected 99.99.99.123456789012");
+            + nodeEnvData['appmetrics.version'] + ", expected 99.99.99.123456789012 (or 99.99.99-dev.99.12345678901)");
   }
 
   if (nodeEnvData['agentcore.version'])


### PR DESCRIPTION
The tests assumed the build identifier would look like one from a
full release and did not recognise a build identifier from a dev
release.

For example, this build id for release version 1.0.7 was recognised:
    1.0.7.201602110606

...but this build id for development version 1.0.8-dev.0 was not:
    1.0.8-dev.0.201604071706

This commit changes the test to recognise the build identifer from
a dev release.

Related: #186