### PR TITLE
Fix crash on shutdown

### DIFF
--- a/src/plugins/node/prof/nodeprofplugin.cpp
+++ b/src/plugins/node/prof/nodeprofplugin.cpp
@@ -396,8 +396,8 @@ extern "C" {
 			ReleaseProfile(profile);
 		}
 
-		uv_close((uv_handle_t*) asyncEnable, cleanupHandle);
-		uv_close((uv_handle_t*) asyncDisable, cleanupHandle);
+		uv_close((uv_handle_t*) asyncEnable, NULL);
+		uv_close((uv_handle_t*) asyncDisable, NULL);
 	
 		return 0;
 	}


### PR DESCRIPTION
PR #185 changed some structs to be static instead of
dynamically allocated. Unfortunately the corresponding
deallocations were not removed causing some environments
to abort() when freeing the invalid (non-heap) pointers.

Fixes: #186