### PR TITLE
Fix recursive require of appmetrics

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -17,7 +17,7 @@
 var timer = require("./timer.js");
 var util = require('util');
 var domain = require('domain');
-var am = require('appmetrics');
+var am = require('../');
 
 /*
  * Global Request Tracking

--- a/tests/test_runner.js
+++ b/tests/test_runner.js
@@ -23,7 +23,7 @@ process.argv.forEach(function(elem) {
 var agent;
 if (!global)
 {
-  agent = require('appmetrics');
+  agent = require('../');
   agent.start();
 
   // Make agent visible for other script files.


### PR DESCRIPTION
A package such as appmetrics cannot require itself by name
(`require('appmetrics')`), its unresolvable. If and only if appmetrics happens
to be installed as a dependency of a package will that work.

An example of when it doesn't is its own unit tests. If you clone appmetrics
and run its unit tests, they fail:

	ibm/appmetrics (adapter % u=) % npm test

	> appmetrics@1.0.9-dev.0 test /home/sam/w/ibm/appmetrics
	> node tests/test_runner.js

	module.js:339
	    throw err;
	    ^

	Error: Cannot find module 'appmetrics'