### PR TITLE
Covers node-hc failure test case using -f flag

### DIFF
--- a/tests/api_tests.js
+++ b/tests/api_tests.js
@@ -15,8 +15,8 @@
  *******************************************************************************/
  
 var app = require('./test_app');
-var monitor = app.agent.monitor();
-app.agent.enable("profiling");
+var monitor = app.appmetrics.monitor();
+app.appmetrics.enable("profiling");
 
 var tap = require('tap');
 tap.plan(6); // NOTE: This needs to be updated when tests are added/removed

--- a/tests/test_app.js
+++ b/tests/test_app.js
@@ -13,18 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *******************************************************************************/
-var global = false;
+
+//Default behaviour for npm test - app will be closed with endRun() so timeout not needed
+var timeout = false;
+var agent = true;
 
 process.argv.forEach(function(elem) {
-  if (elem == '-g'){
-    global = true;
-  }
+	
+	//Running globally with node-hc - testing agent runs and doesn't crash process
+	if (elem == '-g'){
+		timeout = true;
+		agent = false;
+	}
+	
+	//Running with node-hc and including agent - this should fail
+	if (elem == '-f'){
+		agent = true;
+		timeout = true;
+	}
 });
 
-var agent;
+var appmetrics;
 
 //If running global test, run long enough to ensure the agent has loaded and process doesn't crash
-if (global) {
+if (timeout) {
 	var duration_secs = process.argv[2] || 10; //Default 10 seconds for global tests
 	setTimeout(function(){
 		clearInterval(ih);
@@ -32,12 +44,12 @@ if (global) {
 }
 
 //If being run from other test, start the agent and make available
-else {
-	agent = require('../');
-	agent.start();
+if (agent) {
+	appmetrics = require('../');
+	appmetrics.start();
 
 	// Make agent visible for other script files.
-	module.exports.agent = agent;
+	module.exports.appmetrics = appmetrics;
 }
 
 //Write a string to memory on timer


### PR DESCRIPTION
Needed to cover the test case of starting the agent while running with node-hc which should fail with an error message of conflicting installations
