### PR TITLE
fix for lrtime node 10

### DIFF
--- a/src/appmetrics.cpp
+++ b/src/appmetrics.cpp
@@ -525,10 +525,17 @@ void lrtime(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     timespec ts = {0, 0};
     clock_gettime(clock_id, &ts);
       
+#if NODE_VERSION_AT_LEAST(0, 11, 0) // > v0.11+
     v8::Isolate* isolate = info.GetIsolate();
     v8::Local<v8::Array> result = v8::Array::New(isolate, 2);
     result->Set(0, v8::Number::New(isolate, ts.tv_sec));
     result->Set(1, v8::Integer::NewFromUnsigned(isolate, ts.tv_nsec));
+#else
+    v8::Local<v8::Array> result = v8::Array::New(2);
+    result->Set(0, v8::Number::New(ts.tv_sec));
+    result->Set(1, v8::Integer::NewFromUnsigned(ts.tv_nsec));
+#endif
+    
     info.GetReturnValue().Set(result);
 }
 #endif


### PR DESCRIPTION
In node 10, the new array, number and newFromUnsigned integer functions only accept 1 argument.