### PR TITLE
refactored express probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Node Application Metrics provides the following built-in data collection sources
  Memory             | Process and system memory usage
  GC                 | Node/V8 garbage collection statistics
  Event Loop         | Event loop latency information
+ Express            | Express Web Framework application request monitoring
  Loop               | Event loop timing metrics
  Function profiling | Node/V8 function profiling (disabled by default)
  HTTP               | HTTP request calls made of the application
@@ -158,6 +159,7 @@ monitoring.on('cpu', function (cpu) {
     console.log('[' + new Date(cpu.time) + '] CPU: ' + cpu.process);
 });
 ```
+
 ## Health Center Eclipse IDE client
 ### Connecting to the client
 Connecting to the Health Center client requires the additional installation of a MQTT broker. The Node Application Metrics agent sends data to the MQTT broker specified in the `appmetrics.properties` file. Installation and configuration documentation for the Health Center client is available from the [Health Center documentation in IBM Knowledge Center][2].
@@ -177,14 +179,14 @@ Stops the appmetrics monitoring agent. If the agent is not running this function
 
 ### appmetrics.enable(`type`, `config`)
 Enable data generation of the specified data type.
-* `type` (String) the type of event to start generating data for. Values of `eventloop`, `profiling`, `http`, `mongo`, `socketio`, `mqlight`, `postgresql`, `mqtt`, `mysql`, `redis`, `riak`, `memcached`, `oracledb`, `oracle`, `strong-oracle`, `requests` and `trace` are currently supported. As `trace` is added to request data, both `requests` and `trace` must be enabled in order to receive trace data.
+* `type` (String) the type of event to start generating data for. Values of `eventloop`, `express`, `profiling`, `http`, `mongo`, `socketio`, `mqlight`, `postgresql`, `mqtt`, `mysql`, `redis`, `riak`, `memcached`, `oracledb`, `oracle`, `strong-oracle`, `requests` and `trace` are currently supported. As `trace` is added to request data, both `requests` and `trace` must be enabled in order to receive trace data.
 * `config` (Object) (optional) configuration map to be added for the data type being enabled. (see *[setConfig](#set-config)*) for more information.
 
 The following data types are disabled by default: `profiling`, `requests`, `trace`
 
 ### appmetrics.disable(`type`)
 Disable data generation of the specified data type.
-* `type` (String) the type of event to stop generating data for. Values of `eventloop`, `profiling`, `http`, `mongo`, `socketio`, `mqlight`, `postgresql`, `mqtt`, `mysql`, `redis`, `riak`, `memcached`, `oracledb`, `oracle`, `strong-oracle`, `requests` and `trace` are currently supported.
+* `type` (String) the type of event to stop generating data for. Values of `eventloop`, `express`, `profiling`, `http`, `mongo`, `socketio`, `mqlight`, `postgresql`, `mqtt`, `mysql`, `redis`, `riak`, `memcached`, `oracledb`, `oracle`, `strong-oracle`, `requests` and `trace` are currently supported.
 
 <a name="set-config"></a>
 ### appmetrics.setConfig(`type`, `config`)
@@ -393,6 +395,14 @@ Emitted when a PostgreSQL query is made to the `pg` module.
     * `time` (Number) the milliseconds when the PostgreSQL query was made. This can be converted to a Date using `new Date(data.time)`.
     * `query` (String) the query made of the PostgreSQL database.
     * `duration` (Number) the time taken for the PostgreSQL query to be responded to in ms.
+
+### Event: 'express'
+Emitted when an express request finishes its response.
+* `data` (Object) the data from the Express request/response.
+    * `method` (String) The HTTP method for this request.
+    * `url` (String) The target URL for this request.
+    * `statusCode` (Number) The HTTP status code of the response.
+    * `duration` (Number) The time in ms between receiving the request and sending the response.
 
 ## Troubleshooting
 Find below some possible problem scenarios and corresponding diagnostic steps. Updates to troubleshooting information will be made available on the [appmetrics wiki][3]: [Troubleshooting](https://github.com/RuntimeTools/appmetrics/wiki/Troubleshooting). If these resources do not help you resolve the issue, you can open an issue on the Node Application Metrics [appmetrics issue tracker][5].

--- a/probes/express-probe.js
+++ b/probes/express-probe.js
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright 2015 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*******************************************************************************/
+var Probe = require('../lib/probe.js');
+var aspect = require('../lib/aspect.js');
+var request = require('../lib/request.js');
+var util = require('util');
+var am = require('../');
+
+function ExpressProbe() {
+  Probe.call(this, 'express');
+}
+
+util.inherits(ExpressProbe, Probe);
+
+// This method attaches the probe to the instance of the postgres module (target)
+ExpressProbe.prototype.attach = function(name, target) {
+
+  var that = this;
+  if( name != 'express' ) return target;
+  if( target.__ddProbeAttached__ ) return target;
+  target.__ddProbeAttached__ = true;
+
+  var applicationMethods = ['checkout', 'copy', 'delete', 'get', 'head', 'lock', 'merge', 'mkactivity',
+                            'mkcol', 'move', 'm-search', 'notify', 'options', 'patch', 'post', 'purge', 
+                            'put', 'report', 'search', 'subscribe', 'trace', 'unlock', 'unsubscribe'];
+
+  // Get the new target after the express constructor has been called
+  var newTarget = aspect.afterConstructor(target, {});
+
+  // Map the application object to the newTarget
+  newTarget = newTarget.application;
+
+  // Ensure we are only attaching the probe to this target once
+  if (!newTarget.__ddProbeAttached__) {
+    newTarget.__ddProbeAttached__ = true;
+
+    // Before we make the call to an applicaton method
+    aspect.before(newTarget, applicationMethods, function(target, methodName, methodArgs, probeData) {
+      
+      // Patch the callback - i.e. the user's function when someone vists an application URL
+      aspect.aroundCallback(methodArgs, probeData, function(target, args, probeData) {
+        that.metricsProbeStart(probeData, methodName, methodArgs);
+        that.requestProbeStart(probeData, methodName, methodArgs);
+
+      }, function(target, args, probeData, ret) {
+          methodArgs.statusCode = args[1].statusCode;
+          that.metricsProbeEnd(probeData, methodName, methodArgs);
+          that.requestProbeEnd(probeData, methodName, methodArgs);
+      });
+    });
+  }
+  return target;
+}
+
+/*
+ * Lightweight metrics probe for express queries
+ * 
+ * These provide:
+ *      time:       time event started
+ *      url:        the url visited
+ *      method:     the HTTP method called
+ *      statusCode: the HTTP status code returned
+ *      duration:   the time for the request to respond
+ */
+ExpressProbe.prototype.metricsEnd = function(probeData, methodName, methodArgs) {
+  probeData.timer.stop();
+  var expressMetrics = {
+    time: probeData.timer.startTimeMillis, 
+    url: methodArgs[0], 
+    method: methodName, 
+    statusCode: methodArgs.statusCode, 
+    duration: probeData.timer.timeDelta
+  }
+  am.emit('express', expressMetrics);
+};
+
+// Heavyweight request probes for express queries 
+ExpressProbe.prototype.requestStart = function (probeData, target, method, methodArgs) {
+  probeData.req = request.startRequest( 'HTTP', 'request', false, probeData.timer );
+  probeData.req.setContext({url: methodArgs[0]});
+};
+
+ExpressProbe.prototype.requestEnd = function (probeData, method, methodArgs) {
+  probeData.req.stop({url: methodArgs[0]});
+};
+
+module.exports = ExpressProbe;


### PR DESCRIPTION
Changed the express probe so a user can use the monitoring API to monitor express applications, instead of configuring express with the `use` function.