### PR TITLE
Move tap to dev dependency, not runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
   "dependencies": {
     "nan": "2.x",
     "node-gyp": "2.x",
-    "tap": "5.7.x",
     "tar": "2.x"
+  },
+  "devDependencies": {
+    "tap": "^5.7.x"
   },
   "scripts": {
     "test": "tap --reporter tap tests/api_tests.js",


### PR DESCRIPTION
Don't know if the tests pass, because of https://github.com/RuntimeTools/appmetrics/issues/271, but I was noticing that appmetrics had a an unusual number of dependencies when installed as a dependency of strong-supervisor.