### PR TITLE
Undo removal of NAN dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
     "node-hc": "bin/appmetrics-cli.js"
   },
   "dependencies": {
+    "nan": "2.x",
     "tar": "2.x"
   },
   "devDependencies": {
-    "nan": "2.x",
     "node-gyp": "2.x",
     "tap": "^5.7.x"
   },


### PR DESCRIPTION
Add NAN back as a dependency (was removed in error in #281)