### PR TITLE
Do not export lrtime if it is not implemented

### DIFF
--- a/index.js
+++ b/index.js
@@ -241,9 +241,7 @@ module.exports.monitor = function() {
     return this.api;
 };
 
-module.exports.lrtime = function() {
-    return agent.lrtime();
-};
+module.exports.lrtime = agent.lrtime;
 
 module.exports.configure = function(options) {
     options = options || {};

--- a/tests/api_tests.js
+++ b/tests/api_tests.js
@@ -19,9 +19,20 @@ var monitor = app.appmetrics.monitor();
 app.appmetrics.enable("profiling");
 
 var tap = require('tap');
-tap.plan(5); // NOTE: This needs to be updated when tests are added/removed
+tap.plan(6); // NOTE: This needs to be updated when tests are added/removed
 tap.tearDown(function(){
 	app.endRun();
+});
+
+tap.test('lrtime is a function or undefined', function(t) {
+  var lrtime = app.appmetrics.lrtime;
+
+  if (lrtime) {
+    t.doesNotThrow(lrtime, 'callable, not just present');
+  } else {
+    t.notEqual(process.platform, 'linux', 'lrtime mandatory on linux');
+  }
+  t.end();
 });
 
 var completedTests = {}; //Stores which tests have been run, ensures single run per test


### PR DESCRIPTION
If lrtime is not implemented (and it is currently only implemented on
Linux), then do not export it as a function, allowing users of
appmetrics to implement a simple feature test to see if it is available.

@sjanuary @stalleyj This blocks strong-supervisor on non-linux platforms. The previous implementation of `appmetrics.lrtime()` would throw with "undefined is not a function" on non-linux platforms.