### PR TITLE
Let npm handle calling of node-gyp

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,10 @@
     "tar"
   ],
   "devDependencies": {
-    "node-gyp": "3.x",
     "tap": "7.x"
   },
   "scripts": {
-    "test": "tap --reporter tap tests/api_tests.js",
-    "install": "node-gyp rebuild"
+    "test": "tap --reporter tap tests/api_tests.js"
   },
   "directories": {
     "lib": "lib",


### PR DESCRIPTION
node-gyp support is built into npm, using it as a direct dependency just
makes installs slower, and the package more complex.
