### PR TITLE
Bundle dependencies of the install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "nan": "2.x",
     "tar": "2.x"
   },
+  "bundleDependencies": [
+    "tar"
+  ],
   "devDependencies": {
     "node-gyp": "2.x",
     "tap": "^5.7.x"


### PR DESCRIPTION
The install script requires the tar package dependency to be completely
installed before it runs. npm@2 does not guarantee this (see
https://github.com/npm/npm/issues/5001). It can be guaranteed only by
bundling the tar dependency.