### PR TITLE
Update dependencies for node-gyp and tap and reinstate request dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "tar"
   ],
   "devDependencies": {
-    "node-gyp": "2.x",
-    "tap": "^5.7.x"
+    "node-gyp": "3.x",
+    "tap": "7.x"
   },
   "scripts": {
     "test": "tap --reporter tap tests/api_tests.js",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
   },
   "dependencies": {
     "nan": "2.x",
-    "tar": "2.x"
+    "tar": "2.x",
+    "request": "2.x"
   },
   "bundleDependencies": [
-    "tar"
+    "tar",
+    "request"
   ],
   "devDependencies": {
     "node-gyp": "3.x",


### PR DESCRIPTION
I have run this change through the appmetrics build system and the tests are passing on all Node levels and all platforms so it should be safe to update these dependencies.