### PR TITLE
Re-remove request dependency - not needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,10 @@
   },
   "dependencies": {
     "nan": "2.x",
-    "tar": "2.x",
-    "request": "2.x"
+    "tar": "2.x"
   },
   "bundleDependencies": [
-    "tar",
-    "request"
+    "tar"
   ],
   "devDependencies": {
     "node-gyp": "3.x",


### PR DESCRIPTION
'request' dependency was removed, but this caused a build breakage in the appmetrics build system so it was reinstated.  Turns out it's definitely not needed and can be safely removed.