### PR TITLE
Alter binding.gyp targets to solve local build problem on Windows

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -57,7 +57,7 @@
 
   "targets": [
     {
-      "target_name": "agentcore",
+      "target_name": "omr-agentcore",
       "type": "none",
       "dependencies": [
         "<(agentcoredir)/binding.gyp:external",
@@ -128,7 +128,7 @@
       "target_name": "install",
       "type": "none",
       "dependencies": [
-        "agentcore",
+        "omr-agentcore",
         "appmetrics",
         "nodeenvplugin",
         "nodegcplugin",


### PR DESCRIPTION
C:\nodereport\node_modules\appmetrics>if not defined npm_config_node_gyp (node "C:\nodejs\node_modules\npm\bin\node-gyp-bin\\..\..\node_modules\node-gyp\bin\node-gyp
.js" rebuild )  else (node "" rebuild )
Warning: Missing input files:
C:\nodereport\node_modules\appmetrics\build\..\omr-agentcore\plugins\cpuplugin.dll
C:\nodereport\node_modules\appmetrics\build\..\omr-agentcore\plugins\hcmqtt.dll
C:\nodereport\node_modules\appmetrics\build\..\omr-agentcore\plugins\hcapiplugin.dll
C:\nodereport\node_modules\appmetrics\build\..\omr-agentcore\plugins\envplugin.dll
C:\nodereport\node_modules\appmetrics\build\..\omr-agentcore\plugins\memoryplugin.dll
C:\nodereport\node_modules\appmetrics\build\..\omr-agentcore\agentcore.dll
Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.
C:\nodereport\node_modules\appmetrics\build\binding.sln : Solution file error MSB5004: The solution file has two projects named "agentcore".
gyp ERR! build error
gyp ERR! stack Error: `C:\Program Files (x86)\MSBuild\12.0\bin\msbuild.exe` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onExit (C:\nodejs\node_modules\npm\node_modules\node-gyp\lib\build.js:276:23)
gyp ERR! stack     at emitTwo (events.js:106:13)
gyp ERR! stack     at ChildProcess.emit (events.js:191:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:204:12)
gyp ERR! System Windows_NT 6.1.7601
gyp ERR! command "C:\\nodejs\\node.exe" "C:\\nodejs\\node_modules\\npm\\node_modules\\node-gyp\\bin\\node-gyp.js" "rebuild"
gyp ERR! cwd C:\nodereport\node_modules\appmetrics
gyp ERR! node -v v6.2.0
gyp ERR! node-gyp -v v3.3.1
gyp ERR! not ok
npm WARN enoent ENOENT: no such file or directory, open 'C:\nodereport\package.json'
npm WARN nodereport No description
npm WARN nodereport No repository field.
npm WARN nodereport No README data
npm WARN nodereport No license field.
npm ERR! Windows_NT 6.1.7601
npm ERR! argv "C:\\nodejs\\node.exe" "C:\\nodejs\\node_modules\\npm\\bin\\npm-cli.js" "install" "\\Users\\IBM_ADMIN\\Desktop\\GitRepos\\mattcolegate\\appmetrics"
npm ERR! node v6.2.0
npm ERR! npm  v3.8.9
npm ERR! code ELIFECYCLE

npm ERR! appmetrics@1.1.3 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the appmetrics@1.1.3 install script 'node-gyp rebuild'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the appmetrics package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-gyp rebuild
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs appmetrics
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls appmetrics
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     C:\nodereport\npm-debug.log

C:\nodereport>