### PR TITLE
Remove nodereport and heapdump capability from appmetrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,12 +223,6 @@ Allows custom monitoring events to be added into the Node Application Metrics ag
 * `type` (String) the name you wish to use for the data. A subsequent event of that type will be raised, allowing callbacks to be registered for it.
 * `data` (Object) the data to be made available with the event. The object must not contain circular references, and by convention should contain a `time` value representing the milliseconds when the event occurred.
 
-### appmetrics.writeHeapSnapshot([filename],[callback])
-Dumps the v8 heap via `heapdump`. For more information, see [the heapdump README](https://github.com/bnoordhuis/node-heapdump/blob/master/README.md)
-
-### appmetrics.nodereport()
-Provides an instance of `nodereport` that can be used to obtain a human-readable diagnostic summary. For more information, see [the nodereport README](https://github.com/nodejs/nodereport/blob/master/README.md)
-
 ### appmetrics.monitor()
 Creates a Node Application Metrics agent client instance. This can subsequently be used to get environment data and subscribe to data events. This function will start the appmetrics monitoring agent if it is not already running.
 

--- a/index.js
+++ b/index.js
@@ -24,7 +24,6 @@ var os = require("os")
 var aspect = require('./lib/aspect.js');
 var request = require('./lib/request.js');
 var fs = require('fs');
-var nodereport = require('nodereport');
 var agent = require("./appmetrics")
 var headlessZip = require("./headless_zip.js")
 
@@ -304,12 +303,4 @@ module.exports.start = function () {
     headlessZip.setHeadlessOutputDir(headlessOutputDir);
   }
   agent.start();
-}
-
-module.exports.nodereport = function() {
-    return nodereport;
-}
-
-module.exports.writeHeapSnapshot = function() {
-    return require('heapdump').writeSnapshot.apply(null, arguments);
 }

--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
     "node-hc": "bin/appmetrics-cli.js"
   },
   "dependencies": {
-    "heapdump": "0.x",
     "nan": "2.x",
-    "nodereport": "1.x",
     "tar": "2.x",
     "jszip": "3.0.x"
   },


### PR DESCRIPTION
Remove this from next release: needs reworking for vNext.Next.