### PR TITLE
Fix for #345 - headless fails on windows

### DIFF
--- a/src/headlessutils.cpp
+++ b/src/headlessutils.cpp
@@ -17,6 +17,7 @@
 
 #include "headlessutils.h"
 #include <iostream>
+#include <string>
 #include "nan.h"
 #include "uv.h"
 
@@ -31,12 +32,13 @@ void setZipFunction(Nan::Callback* zF) {
 uv_async_t async_zip;
 
 uv_loop_t* loop;
-const char* outputDir;
+std::string outputDir;
 
 void asyncfunc(uv_async_t* handle) {
 	Nan::HandleScope scope;
  	v8::Isolate* isolate = v8::Isolate::GetCurrent();
-  	v8::Local<v8::Value> argv[] = { v8::String::NewFromUtf8(isolate, outputDir) };
+    printf("outputdir in asyncfunc is %s\n", outputDir.c_str());
+  	v8::Local<v8::Value> argv[] = { v8::String::NewFromUtf8(isolate, outputDir.c_str()) };
   	headless::zipFunction->Call(1, argv);
 }
 
@@ -53,7 +55,8 @@ void stop() {
 }
 
 void zip(const char* dir) {
-	outputDir = dir;
+    printf("Headless utils: Outputdir = %s\n", dir);
+	outputDir = std::string(dir);
 	uv_async_send(&async_zip);
 }
 

--- a/src/headlessutils.cpp
+++ b/src/headlessutils.cpp
@@ -37,7 +37,6 @@ std::string outputDir;
 void asyncfunc(uv_async_t* handle) {
 	Nan::HandleScope scope;
  	v8::Isolate* isolate = v8::Isolate::GetCurrent();
-    printf("outputdir in asyncfunc is %s\n", outputDir.c_str());
   	v8::Local<v8::Value> argv[] = { v8::String::NewFromUtf8(isolate, outputDir.c_str()) };
   	headless::zipFunction->Call(1, argv);
 }
@@ -55,7 +54,6 @@ void stop() {
 }
 
 void zip(const char* dir) {
-    printf("Headless utils: Outputdir = %s\n", dir);
 	outputDir = std::string(dir);
 	uv_async_send(&async_zip);
 }


### PR DESCRIPTION
String passed was being re-allocated, use std:string to create a copy instead
Fixes #345