### PR TITLE
Fix a problem with double initialization

### DIFF
--- a/src/plugins/node/loop/nodeloopplugin.cpp
+++ b/src/plugins/node/loop/nodeloopplugin.cpp
@@ -68,13 +68,17 @@ static void GetLoopInformation(uv_timer_s *data) {
 #else
 static void GetLoopInformation(uv_timer_s *data, int status) {
 #endif
+	double mean = std::numeric_limits<double>::infinity();
+	if (num != 0) {
+		mean = sum / num;
+	}
 
 	std::stringstream contentss;
 	contentss << "NodeLoopData";
 	contentss << "," << min;
 	contentss << "," << max;
 	contentss << "," << num;
-	contentss << "," << sum / num;
+	contentss << "," << mean;
 	contentss << '\n';
 
 	std::string content = contentss.str();


### PR DESCRIPTION
The check_handle has a problem with double initialization. So instead of trying to initialize on start, do it when the plugin is initialized and just start and stop the listening loops.

This addresses some of #336. There is still problems with the system reconnecting after the 2nd start, but that will probably need to be addressed separately. 