### PR TITLE
Fixes error when `before` is called without a target

### DIFF
--- a/lib/aspect.js
+++ b/lib/aspect.js
@@ -47,6 +47,8 @@ exports.findCallbackArg = function(args) {
 };
 
 exports.before = function(target, meths, hookBefore) {
+	if(!target) return;
+
 	if(!Array.isArray(meths)) {
 		meths = [meths];
 	}


### PR DESCRIPTION
Quick fix for when `before` is called without a valid target.

Fixes #241.