### PR TITLE
oracledb: Cannot read property 'OBJECT' of undefined

### DIFF
--- a/probes/oracledb-probe.js
+++ b/probes/oracledb-probe.js
@@ -31,7 +31,7 @@ util.inherits(OracleDBProbe, Probe);
 OracleDBProbe.prototype.attach = function(name, target) {
 	var that = this;
 	if( name != 'oracledb' ) return target;
-	if(target.__probeAttached__) return;
+	if(target.__probeAttached__) return target;
 	target.__probeAttached__ = true;
 
 	// After 'getConnection' (single-user connection model)


### PR DESCRIPTION
Hi, I'm having problems using `appmetrics` with `oracledb`.

```
const appmetrics = require('appmetrics');

const oracledb = require('oracledb');
oracledb.outFormat = oracledb.OBJECT;
```

My code crashed with a `Cannot read property 'OBJECT' of undefined`

```
/usr/src/app/src/index.js:4
      oracledb.outFormat = oracledb.OBJECT;
TypeError: Cannot read property 'OBJECT' of undefined
```

This patch should fix the problem.