### PR TITLE
Fix node version check for 6.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "devDependencies": {
     "node-gyp": "3.x",
+    "semver": "^5.3.0",
     "tap": "7.x"
   },
   "scripts": {

--- a/tests/api_tests.js
+++ b/tests/api_tests.js
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *******************************************************************************/
- 
+'use strict'
+
 var app = require('./test_app');
 var appmetrics = app.start();
 var monitor = app.appmetrics.monitor();
+var semver = require('semver');
 app.appmetrics.enable("profiling");
 
 var tap = require('tap');
@@ -322,8 +324,7 @@ function runNodeEnvTests(nodeEnvData, t) {
                                          t.ok(parseInt(nodeEnvData['max.old.space.size']) > 0,
                                               "max.old.space.size is positive");
 
-                                              var nodeVersion = Number(process.version.match(/^v(\d+\.\d+)/)[1]);
-                                              if(nodeVersion >= 6.5) { // issue 283
+                                              if(semver.gt(process.version, '6.5.0')) { // issue 283
                                                 t.ok(2*parseInt(nodeEnvData['max.semi.space.size']) + parseInt(nodeEnvData['max.old.space.size']) === parseInt(nodeEnvData['heap.size.limit']),
                                                      'Values for max.old.space.size and max.semi.space.size match heap.size.limit');
                                               } else {


### PR DESCRIPTION
The previous code converted the node version to a float and compared to 6.5. This
doesn't work for 6.10 (6.10 < 6.5).

Fixes: https://github.com/RuntimeTools/appmetrics/issues/394