### PR TITLE
Specify supported node versions in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "appmetrics",
   "version": "3.0.0",
+  "engines": { "node": ">=4" },
   "description": "Node Application Metrics",
   "bin": {
     "node-hc": "bin/appmetrics-cli.js"


### PR DESCRIPTION
cf. https://docs.npmjs.com/files/package.json#engines
cf. https://developer.ibm.com/node/2017/02/23/node-js-versions-supported-node-application-metrics-versions-4-6-7-remain-supported-support-versions-0-10-0-12-5-dropped/

Its only advisory, but it makes it clear in the package what the support policy is.

/cc @NikCanvin