### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ The Node Application Metrics agent supports the following runtime environments:
   * 64-bit or 32-bit runtime on AIX (PPC32, PPC64)
   * 64-bit runtime on Mac OS X (x64)
 
-<a name="install"></a>
 ### Installation
+
 Node Application Metrics can be installed using **npm** either locally or globally.
 
-**When installed locally** you can access monitoring data via both the API and the Health Center client by modifying your application to use appmetrics (see *[Modifying your application to use the local installation](#run-local)*).
+**When installed locally** you can access monitoring data via both the API and the Health Center client by modifying your application to use appmetrics (see *[Modifying your application to use the local installation](#modifying-your-application-to-use-the-local-installation)*).
 
 To perform a local install:
 ```sh
@@ -73,7 +73,7 @@ $ npm install appmetrics
 ```
 A local install will put the module inside "*`./node_modules` of the current package root*" (see the [npm documentation][4] for more information); usually this is the current directory and in that case the module installation directory will be `./node_modules/appmetrics`.
 
-**When installed globally** you can access monitoring data via the Health Center client (but not the API) by using the `node-hc` command-line utility (see *[The `node-hc` command](#run-global)*).
+**When installed globally** you can access monitoring data via the Health Center client (but not the API) by using the `node-hc` command-line utility (see *[The `node-hc` command](#the-node-hc-command)*).
 
 To perform a global install:
 ```sh
@@ -95,12 +95,11 @@ It also adds the `node-hc` command to another directory tied to your Node.js SDK
 * On other platforms:
   * `<node_install_directory>/bin`
 
-<a name="config"></a>
 ### Configuring Node Application Metrics
 
 Node Application Metrics can be configured in two ways, by using the configuration file described below or via a call to configure(options).
 
-Node Application Metrics comes with a configuration file inside the [module installation directory](#install) (`.../node_modules/appmetrics/appmetrics.properties`). This can be used to configure connection options, logging and data source options. 
+Node Application Metrics comes with a configuration file inside the [module installation directory](#installation) (`.../node_modules/appmetrics/appmetrics.properties`). This can be used to configure connection options, logging and data source options. 
 
 Node Application Metrics will attempt to load `appmetrics.properties` from one of the following locations (in order):
 
@@ -118,9 +117,9 @@ The following options are specific to appmetrics:
   Specifies whether method profiling data will be captured. The default value is `off`.  This specifies the value at start-up; it can be enabled and disabled dynamically as the application runs, either by a monitoring client or the API. 
 
 ## Running Node Application Metrics
-<a name="run-global"></a>
+
 ### The `node-hc` command
-If you [globally installed](#install) this module with npm, you can use the `node-hc` command to run your application instead of the `node` command. This will run your application as it would normally under node (including any node options) but additionally load and start `appmetrics`.
+If you [globally installed](#installation) this module with npm, you can use the `node-hc` command to run your application instead of the `node` command. This will run your application as it would normally under node (including any node options) but additionally load and start `appmetrics`.
 
 ```sh
 $ node-hc app.js
@@ -128,9 +127,8 @@ $ node-hc app.js
 
 The purpose of this mode of operation is to provide monitoring of the application without requiring any changes to the application code. The data is sent to the Health Center Eclipse IDE client.
 
-<a name="run-local"></a>
 ### Modifying your application to use the local installation
-If you [locally install](#install) this module with npm then you will additionally have access to the monitoring data via the `appmetrics` API (see *[API Documentation](#api-doc)*).
+If you [locally install](#installation) this module with npm then you will additionally have access to the monitoring data via the `appmetrics` API (see *[API Documentation](#api-documentation)*).
 
 To load `appmetrics` and get the monitoring API object, add the following to the start-up code for your application:
 ```js
@@ -163,11 +161,10 @@ monitoring.on('cpu', function (cpu) {
 ### Connecting to the client
 Connecting to the Health Center client requires the additional installation of a MQTT broker. The Node Application Metrics agent sends data to the MQTT broker specified in the `appmetrics.properties` file or set via a call to configure(options). Installation and configuration documentation for the Health Center client is available from the [Health Center documentation in IBM Knowledge Center][2].
 
-Note that both the API and the Health Center client can be used at the same time and will receive the same data. Use of the API requires a local install and application modification (see *[Modifying your application to use the local installation](#run-local)*).
+Note that both the API and the Health Center client can be used at the same time and will receive the same data. Use of the API requires a local install and application modification (see *[Modifying your application to use the local installation](#modifying-your-application-to-use-the-local-installation)*).
 
 Further information regarding the use of the Health Center client with Node Application Metrics can be found on the [appmetrics wiki][3]: [Using Node Application Metrics with the Health Center client](https://github.com/RuntimeTools/appmetrics/wiki/Using-Node-Application-Metrics-with-the-Health-Center-client).
 
-<a name="api-doc"></a>
 ## API Documentation
 ### appmetrics.configure(options)
 Sets various properties on the appmetrics monitoring agent. If the agent has already been started, this function does nothing. 
@@ -191,7 +188,7 @@ Stops the appmetrics monitoring agent. If the agent is not running this function
 ### appmetrics.enable(`type`, `config`)
 Enable data generation of the specified data type.
 * `type` (String) the type of event to start generating data for. Values of `eventloop`, `express`, `profiling`, `http`, `http-outbound`, `mongo`, `socketio`, `mqlight`, `postgresql`, `mqtt`, `mysql`, `redis`, `riak`, `memcached`, `oracledb`, `oracle`, `strong-oracle`, `requests` and `trace` are currently supported. As `trace` is added to request data, both `requests` and `trace` must be enabled in order to receive trace data.
-* `config` (Object) (optional) configuration map to be added for the data type being enabled. (see *[setConfig](#set-config)*) for more information.
+* `config` (Object) (optional) configuration map to be added for the data type being enabled. (see *[setConfig](#appmetricssetconfigtype-config)*) for more information.
 
 The following data types are disabled by default: `profiling`, `requests`, `trace`
 
@@ -199,7 +196,6 @@ The following data types are disabled by default: `profiling`, `requests`, `trac
 Disable data generation of the specified data type.
 * `type` (String) the type of event to stop generating data for. Values of `eventloop`, `express`, `profiling`, `http`, `mongo`, `socketio`, `mqlight`, `postgresql`, `mqtt`, `mysql`, `redis`, `riak`, `memcached`, `oracledb`, `oracle`, `strong-oracle`, `requests` and `trace` are currently supported.
 
-<a name="set-config"></a>
 ### appmetrics.setConfig(`type`, `config`)
 Set the configuration to be applied to a specific data type. The configuration available is specific to the data type.
 * `type` (String) the type of event to apply the configuration to.
@@ -448,7 +444,7 @@ By default, a message similar to the following will be written to console output
 `[Fri Aug 21 09:36:58 2015] com.ibm.diagnostics.healthcenter.loader INFO: Node Application Metrics 1.0.1-201508210934 (Agent Core 3.0.5.201508210934)`
 
 ### Error "Conflicting appmetrics module was already loaded by node-hc. Try running with node instead." when using `node-hc`
-This error indicates you are using `node-hc` to run an application that uses the Node Application Metrics monitoring API (see *[Modifying your application to use the local installation](#run-local)*). Resolve this by using `node` to run the application instead. **Alternatively**, you could remove (or disable temporarily) the use of the Node Application Metrics monitoring API in your application.
+This error indicates you are using `node-hc` to run an application that uses the Node Application Metrics monitoring API (see *[Modifying your application to use the local installation](#modifying-your-application-to-use-the-local-installation)*). Resolve this by using `node` to run the application instead. **Alternatively**, you could remove (or disable temporarily) the use of the Node Application Metrics monitoring API in your application.
 
 This error was added to prevent the scenario where 2 instances of the agent can be accidentally created and started in parallel -- the globally installed one created by `node-hc` and the locally installed one created by the `require('appmetrics');` call in an application modified to use the Node Application Metrics monitoring API.
 
@@ -472,7 +468,7 @@ Check:
 * If you have an appropriate version of `libstdc++`installed, ensure it is on the system library path, or use a method (such as setting `LD_LIBRARY_PATH` environment variable on Linux, or LIBPATH environment variable on AIX) to add the library to the search path.
 
 ### No profiling data present for Node.js applications
-Method profiling data is not collected by default, check *[Configuring Node Application Metrics](#config)* for information on how to enable it.
+Method profiling data is not collected by default, check *[Configuring Node Application Metrics](#configuring-node-application-metrics)* for information on how to enable it.
 
 If collection is enabled, an absence of method profiling data from a Node.js application could be caused by the type of tasks that are being run by your application -- it may be running long, synchronous tasks that prevent collection events from being scheduled on the event loop.
 


### PR DESCRIPTION
Per #397, this fixes display of README on npmjs.com -- their markdown parser doesn't seem to like having an HTML tag (e.g. `<a name='..'></a>`) right before a header, causing the header to display as plain text.

This PR removes the manually-inserted anchors and relies instead on the auto-generated anchors (in both GH and npmjs.com), and fixes intrapage links accordingly.

Naturally, this won't affect https://www.npmjs.com/package/appmetrics until the next npm publish.