### PR TITLE
Add null check to request/metrics end

### DIFF
--- a/probes/axon-probe.js
+++ b/probes/axon-probe.js
@@ -120,13 +120,15 @@ AxonProbe.prototype.attach = function(name, target) {
  *		duration:	the time for the request to respond
  */
 AxonProbe.prototype.metricsEnd = function(context, methodName, methodArgs, socketType) {
-	context.timer.stop();
-	// default to quality of service (qos) 0, as that's what the axon module does
-	if( isSendMethod(socketType) ) {
-		am.emit('axon', {time: context.timer.startTimeMillis, method: methodName, duration: context.timer.timeDelta, type: socketType})
-	} else {
-		am.emit('axon', {time: context.timer.startTimeMillis, event: methodName, duration: context.timer.timeDelta, type: socketType})
-	};
+    if(context && context.timer) {
+	    context.timer.stop();
+	    // default to quality of service (qos) 0, as that's what the axon module does
+	    if( isSendMethod(socketType) ) {
+		    am.emit('axon', {time: context.timer.startTimeMillis, method: methodName, duration: context.timer.timeDelta, type: socketType})
+	    } else {
+		    am.emit('axon', {time: context.timer.startTimeMillis, event: methodName, duration: context.timer.timeDelta, type: socketType})
+	    };
+    }
 };
 
 /*
@@ -141,7 +143,8 @@ AxonProbe.prototype.requestStart = function (context, methodName, methodArgs) {
 };
 
 AxonProbe.prototype.requestEnd = function (context, methodName, methodArgs) {
-	context.req.stop({topic: methodArgs[0]});
+    if(context && context.req)
+	    context.req.stop({topic: methodArgs[0]});
 };
 
 module.exports = AxonProbe;

--- a/probes/basho-riak-client-probe.js
+++ b/probes/basho-riak-client-probe.js
@@ -104,25 +104,27 @@ RiakProbe.prototype.attach = function(name, target) {
  *      duration:   The time for the request to respond
  */
 RiakProbe.prototype.metricsEnd = function(probeData, method, methodArgs) {
-    probeData.timer.stop();
-    eventTimer = probeData.timer;
+    if(probeData && probeData.timer) {
+        probeData.timer.stop();
+        eventTimer = probeData.timer;
 
-    //Work out if options, command or query are needed. Defaults to just method
-    var jsonToEmit = {time: eventTimer.startTimeMillis, method: method, duration: eventTimer.timeDelta};
-    var key = '';
+        //Work out if options, command or query are needed. Defaults to just method
+        var jsonToEmit = {time: eventTimer.startTimeMillis, method: method, duration: eventTimer.timeDelta};
+        var key = '';
 
-    if (optionsAndCallbackMethods.indexOf(method) > -1) {
-        key = 'options';
-    } else if (commandMethods.indexOf(method) > -1) {
-        key = 'command';
-    } else if (queryMethods.indexOf(method) > -1) {
-        key = 'query';
+        if (optionsAndCallbackMethods.indexOf(method) > -1) {
+            key = 'options';
+        } else if (commandMethods.indexOf(method) > -1) {
+            key = 'command';
+        } else if (queryMethods.indexOf(method) > -1) {
+            key = 'query';
+        }
+
+        if (key != '') {
+            jsonToEmit[key] = methodArgs[0];
+        }
+        am.emit('riak', jsonToEmit);
     }
-
-    if (key != '') {
-        jsonToEmit[key] = methodArgs[0];
-    }
-    am.emit('riak', jsonToEmit);
 };
 
 /*
@@ -133,7 +135,8 @@ RiakProbe.prototype.requestStart = function (probeData, method, methodArgs) {
 };
 
 RiakProbe.prototype.requestEnd = function (probeData, method, methodArgs) {
-    probeData.req.stop({method: method});
+    if(probeData && probeData.req)
+        probeData.req.stop({method: method});
 };
 
 module.exports = RiakProbe;

--- a/probes/express-probe.js
+++ b/probes/express-probe.js
@@ -78,15 +78,17 @@ ExpressProbe.prototype.attach = function(name, target) {
  *      duration:   the time for the request to respond
  */
 ExpressProbe.prototype.metricsEnd = function(probeData, methodName, methodArgs) {
-  probeData.timer.stop();
-  var expressMetrics = {
-    time: probeData.timer.startTimeMillis, 
-    url: methodArgs[0], 
-    method: methodName, 
-    statusCode: methodArgs.statusCode, 
-    duration: probeData.timer.timeDelta
+  if(probeData && probeData.timer) {
+    probeData.timer.stop();
+    var expressMetrics = {
+      time: probeData.timer.startTimeMillis, 
+      url: methodArgs[0], 
+      method: methodName, 
+      statusCode: methodArgs.statusCode, 
+      duration: probeData.timer.timeDelta
+    }
+    am.emit('express', expressMetrics);
   }
-  am.emit('express', expressMetrics);
 };
 
 // Heavyweight request probes for express queries 
@@ -96,7 +98,8 @@ ExpressProbe.prototype.requestStart = function (probeData, method, methodArgs) {
 };
 
 ExpressProbe.prototype.requestEnd = function (probeData, method, methodArgs) {
-  probeData.req.stop({url: methodArgs[0]});
+  if(probeData && probeData.req)
+    probeData.req.stop({url: methodArgs[0]});
 };
 
 module.exports = ExpressProbe;

--- a/probes/http-outbound-probe.js
+++ b/probes/http-outbound-probe.js
@@ -161,9 +161,11 @@ function formatURL(httpOptions) {
  *   statusCode:      HTTP status code
  */
 HttpOutboundProbe.prototype.metricsEnd = function(probeData, method, url, res, headers) {
-    probeData.timer.stop();
-    am.emit('http-outbound', {time: probeData.timer.startTimeMillis, method: method, url: url,
-        duration: probeData.timer.timeDelta, statusCode: res.statusCode, contentType:res.headers?res.headers['content-type']:"undefined", requestHeaders: headers});
+    if(probeData && probeData.timer) {
+        probeData.timer.stop();
+        am.emit('http-outbound', {time: probeData.timer.startTimeMillis, method: method, url: url,
+            duration: probeData.timer.timeDelta, statusCode: res.statusCode, contentType:res.headers?res.headers['content-type']:"undefined", requestHeaders: headers});
+    }
 };
 
 /*
@@ -176,7 +178,8 @@ HttpOutboundProbe.prototype.requestStart = function (probeData, method, url) {
 };
 
 HttpOutboundProbe.prototype.requestEnd = function (probeData, method, url, res, headers) {
-    probeData.req.stop({url: url, statusCode: res.statusCode, contentType:res.headers?res.headers['content-type']:"undefined", requestHeaders: headers});
+    if(probeData && probeData.req)
+        probeData.req.stop({url: url, statusCode: res.statusCode, contentType:res.headers?res.headers['content-type']:"undefined", requestHeaders: headers});
 };
 
 

--- a/probes/http-probe.js
+++ b/probes/http-probe.js
@@ -99,8 +99,10 @@ HttpProbe.prototype.filterUrl = function(req) {
  */
 
 HttpProbe.prototype.metricsEnd = function(probeData, method, url, res, httpReq) {
-	probeData.timer.stop();
-	am.emit('http', {time: probeData.timer.startTimeMillis, method: method, url: url, duration: probeData.timer.timeDelta, header: res._header, statusCode: res.statusCode, contentType: res.getHeader('content-type'), requestHeader: httpReq.headers});
+    if(probeData && probeData.timer) {
+	    probeData.timer.stop();
+	    am.emit('http', {time: probeData.timer.startTimeMillis, method: method, url: url, duration: probeData.timer.timeDelta, header: res._header, statusCode: res.statusCode, contentType: res.getHeader('content-type'), requestHeader: httpReq.headers});
+    }
 };
 
 /*
@@ -114,7 +116,8 @@ HttpProbe.prototype.requestStart = function (probeData, method, url) {
 };
 
 HttpProbe.prototype.requestEnd = function (probeData, method, url) {
-    probeData.req.stop({url: url });
+    if(probeData && probeData.req)
+        probeData.req.stop({url: url });
 };
 	
 /*

--- a/probes/leveldown-probe.js
+++ b/probes/leveldown-probe.js
@@ -79,16 +79,18 @@ LeveldownProbe.prototype.attach = function(name, target){
  
  
 LeveldownProbe.prototype.metricsEnd = function(probeData, method, methodArgs) {
-	probeData.timer.stop();
-	if (method == 'put'){
-		am.emit('leveldown', {time: probeData.timer.startTimeMillis, method: method, key: methodArgs[0], value: methodArgs[1], duration: probeData.timer.timeDelta});
-	}
-	else if (method == 'del' || method == 'get'){
-		am.emit('leveldown', {time: probeData.timer.startTimeMillis, method: method, key: methodArgs[0], duration: probeData.timer.timeDelta});
-	}
-	else if(method == 'batch'){
-		am.emit('leveldown', {time: probeData.timer.startTimeMillis, method: method, opCount: methodArgs[0].length, duration: probeData.timer.timeDelta});
-	}
+    if(probeData && probeData.timer) {
+	    probeData.timer.stop();
+	    if (method == 'put'){
+		    am.emit('leveldown', {time: probeData.timer.startTimeMillis, method: method, key: methodArgs[0], value: methodArgs[1], duration: probeData.timer.timeDelta});
+	    }
+	    else if (method == 'del' || method == 'get'){
+		    am.emit('leveldown', {time: probeData.timer.startTimeMillis, method: method, key: methodArgs[0], duration: probeData.timer.timeDelta});
+	    }
+	    else if(method == 'batch'){
+		    am.emit('leveldown', {time: probeData.timer.startTimeMillis, method: method, opCount: methodArgs[0].length, duration: probeData.timer.timeDelta});
+	    }
+    }
 };
 
 /*
@@ -100,7 +102,8 @@ LeveldownProbe.prototype.requestStart = function (probeData, dbTarget, method, m
 };
 
 LeveldownProbe.prototype.requestEnd = function (probeData, method, methodArgs) {
-	req.stop({leveldown: methodArgs[0]});
+    if(probeData && probeData.req)
+	    req.stop({leveldown: methodArgs[0]});
 };
 
 module.exports = LeveldownProbe;

--- a/probes/loopback-probe.js
+++ b/probes/loopback-probe.js
@@ -72,22 +72,24 @@ loopbackDJProbe.prototype.attach = function(name, target){
  * 		duration:	the time for the request to respond
  */
 loopbackDJProbe.prototype.metricsEnd = function(probeData, method, methodArgs) {
-	probeData.timer.stop();
-	eventTimer = probeData.timer;
-	am.emit('loopback-datasource-juggler', {time: eventTimer.startTimeMillis, method: method, duration: eventTimer.timeDelta});
+    if(probeData && probeData.timer) {
+	    probeData.timer.stop();
+	    eventTimer = probeData.timer;
+	    am.emit('loopback-datasource-juggler', {time: eventTimer.startTimeMillis, method: method, duration: eventTimer.timeDelta});
+    }
 }
 
 /*
  * Heavyweight request probes for juggler commands
  */
 loopbackDJProbe.prototype.requestStart = function (probeData, target, method, methodArgs) {
-	 req = request.startRequest( 'DB', "query" );
-	 req.setContext({loopbackDJProbe: methodArgs[0]});
+	 probeData.req = request.startRequest( 'DB', "query" );
+	 probeData.req.setContext({loopbackDJProbe: methodArgs[0]});
 };
 
 loopbackDJProbe.prototype.requestEnd = function (probeData, method, methodArgs) {
-	console.log("requestEnd called");
-	req.stop({loopbackDJProbe: methodArgs[0]});
+	if(probeData && probeData.req)
+	    probeData.req.stop({loopbackDJProbe: methodArgs[0]});
 };
 
 module.exports = loopbackDJProbe;

--- a/probes/memcached-probe.js
+++ b/probes/memcached-probe.js
@@ -86,8 +86,10 @@ MemcachedProbe.prototype.attach = function(name, target) {
  * 		duration:	the time for the request to respond
  */
 MemcachedProbe.prototype.metricsEnd = function(context, method, methodArgs) {
-	context.timer.stop();
-	am.emit('memcached', {time: context.timer.startTimeMillis, method: method, key: methodArgs[0], duration: context.timer.timeDelta});
+    if(context && context.timer) {
+	    context.timer.stop();
+	    am.emit('memcached', {time: context.timer.startTimeMillis, method: method, key: methodArgs[0], duration: context.timer.timeDelta});
+    }
 };
 
 /*
@@ -98,7 +100,8 @@ MemcachedProbe.prototype.requestStart = function (context, methodName, methodArg
 };
 
 MemcachedProbe.prototype.requestEnd = function (context, methodName, methodArgs) {
-	context.req.stop({key: methodArgs[0]});
+    if(context && context.req)
+	    context.req.stop({key: methodArgs[0]});
 };
 
 module.exports = MemcachedProbe;

--- a/probes/mongo-probe.js
+++ b/probes/mongo-probe.js
@@ -114,9 +114,11 @@ MongoProbe.prototype.attach = function(name, target) {
  *         collection:  the mongo collection
  */
 MongoProbe.prototype.metricsEnd = function(probeData, collectionName, method, methodArgs) {
-    probeData.timer.stop();
-    am.emit('mongo', {time: probeData.timer.startTimeMillis, query: JSON.stringify(methodArgs[0]), duration: probeData.timer.timeDelta,
-        method: method, collection: collectionName});
+    if(probeData && probeData.timer) {
+        probeData.timer.stop();
+        am.emit('mongo', {time: probeData.timer.startTimeMillis, query: JSON.stringify(methodArgs[0]), duration: probeData.timer.timeDelta,
+            method: method, collection: collectionName});
+    }
 };
 
 /*
@@ -127,7 +129,8 @@ MongoProbe.prototype.requestStart = function (probeData, target, method, methodA
 };
 
 MongoProbe.prototype.requestEnd = function (probeData, method, methodArgs) {
-    probeData.req.stop( { query: JSON.stringify(methodArgs[0]) } );
+    if(probeData && probeData.req)
+        probeData.req.stop( { query: JSON.stringify(methodArgs[0]) } );
 };
 
 module.exports = MongoProbe;

--- a/probes/mqlight-probe.js
+++ b/probes/mqlight-probe.js
@@ -99,42 +99,44 @@ MQLightProbe.prototype.attach = function(name, target) {
  * Lightweight metrics probe end for MQLight messages
  */
 MQLightProbe.prototype.metricsEnd = function(probeData, method, methodArgs, client) {
-	probeData.timer.stop();
-	if(method == 'message') {
-		var data = methodArgs[0];
-		if(data.length > 25) {
-			data = data.substring(0, 22) + "...";
-		}
-		var topic = methodArgs[1].message.topic;
-		am.emit('mqlight', {
-			time : probeData.timer.startTimeMillis,
-			clientid : client.id,
-			data : data,
-			method : method,
-			topic : topic,
-			duration : probeData.timer.timeDelta
-		});
-	} else if(method == 'send') {
-		var data = methodArgs[1];
-		if(data.length > 25) {
-			data = data.substring(0, 22) + "...";
-		}
-		var qos;
-		var options; // options are optional - check number of arguments.
-		if(methodArgs.length > 3) {
-			options = methodArgs[2];
-			qos = options[0];
-		}
-		am.emit('mqlight', {
-			time : probeData.timer.startTimeMillis,
-			clientid : client.id,
-			data : data,
-			method : method,
-			topic : methodArgs[0],
-			qos : qos,
-			duration : probeData.timer.timeDelta
-		});
-	}
+    if(probeData && probeData.timer) {
+	    probeData.timer.stop();
+	    if(method == 'message') {
+		    var data = methodArgs[0];
+		    if(data.length > 25) {
+			    data = data.substring(0, 22) + "...";
+		    }
+		    var topic = methodArgs[1].message.topic;
+		    am.emit('mqlight', {
+			    time : probeData.timer.startTimeMillis,
+			    clientid : client.id,
+			    data : data,
+			    method : method,
+			    topic : topic,
+			    duration : probeData.timer.timeDelta
+		    });
+	    } else if(method == 'send') {
+		    var data = methodArgs[1];
+		    if(data.length > 25) {
+			    data = data.substring(0, 22) + "...";
+		    }
+		    var qos;
+		    var options; // options are optional - check number of arguments.
+		    if(methodArgs.length > 3) {
+			    options = methodArgs[2];
+			    qos = options[0];
+		    }
+		    am.emit('mqlight', {
+			    time : probeData.timer.startTimeMillis,
+			    clientid : client.id,
+			    data : data,
+			    method : method,
+			    topic : methodArgs[0],
+			    qos : qos,
+			    duration : probeData.timer.timeDelta
+		    });
+	    }
+    }
 };
 
 /*
@@ -149,26 +151,28 @@ MQLightProbe.prototype.requestStart = function (probeData, method, methodArgs) {
 };
 
 MQLightProbe.prototype.requestEnd = function (probeData, method, methodArgs, client) {
-	if(method == 'message') {
-		var data = methodArgs[0];
-		if(data.length > 25) {
-			data = data.substring(0, 22) + "...";
-		}
-		var topic = methodArgs[1].message.topic;
-		probeData.req.stop({clientid: client.id, data: data, method: method,  topic: methodArgs[0]});
-	} else if(method == 'send') {
-		var data = methodArgs[1];
-		if(data.length > 25) {
-			data = data.substring(0, 22) + "...";
-		}
-		var qos;
-		var options; // options are optional - check number of arguments.
-		if(methodArgs.length > 3) {
-			options = methodArgs[2];
-			qos = options[0];
-		}
-		probeData.req.stop({clientid: client.id, data: data, method: method,  topic: methodArgs[0], qos: qos});
-	}
+    if(probeData && probeData.req) {
+	    if(method == 'message') {
+		    var data = methodArgs[0];
+		    if(data.length > 25) {
+			    data = data.substring(0, 22) + "...";
+		    }
+		    var topic = methodArgs[1].message.topic;
+		    probeData.req.stop({clientid: client.id, data: data, method: method,  topic: methodArgs[0]});
+	    } else if(method == 'send') {
+		    var data = methodArgs[1];
+		    if(data.length > 25) {
+			    data = data.substring(0, 22) + "...";
+		    }
+		    var qos;
+		    var options; // options are optional - check number of arguments.
+		    if(methodArgs.length > 3) {
+			    options = methodArgs[2];
+			    qos = options[0];
+		    }
+		    probeData.req.stop({clientid: client.id, data: data, method: method,  topic: methodArgs[0], qos: qos});
+	    }
+    }
 };
 
 module.exports = MQLightProbe;

--- a/probes/mqtt-probe.js
+++ b/probes/mqtt-probe.js
@@ -101,13 +101,15 @@ MqttProbe.prototype.attach = function(name, target) {
  *		duration:	the time for the request to respond
  */
 MqttProbe.prototype.metricsEnd = function(context, methodName, methodArgs) {
-	context.timer.stop();
-	// default to quality of service (qos) 0, as that's what the mqtt module does
-	var qos = 0;
-	if (methodArgs[2] && (typeof(methodArgs[2]) !== 'function')) {
-		qos = methodArgs[2].qos;
-	}
-	am.emit('mqtt', {time: context.timer.startTimeMillis, method: methodName, topic: methodArgs[0], qos: qos, duration: context.timer.timeDelta});
+    if(context && context.timer) {
+	    context.timer.stop();
+	    // default to quality of service (qos) 0, as that's what the mqtt module does
+	    var qos = 0;
+	    if (methodArgs[2] && (typeof(methodArgs[2]) !== 'function')) {
+		    qos = methodArgs[2].qos;
+	    }
+	    am.emit('mqtt', {time: context.timer.startTimeMillis, method: methodName, topic: methodArgs[0], qos: qos, duration: context.timer.timeDelta});
+    }
 };
 
 /*
@@ -122,11 +124,13 @@ MqttProbe.prototype.requestStart = function (context, methodName, methodArgs) {
 };
 
 MqttProbe.prototype.requestEnd = function (context, methodName, methodArgs) {
-	var qos = 0;
-	if (methodArgs[2] && (typeof(methodArgs[2]) !== 'function')) {
-		qos = methodArgs[2].qos;
-	}
-	context.req.stop({topic: methodArgs[0], qos: qos});
+    if(context && context.req) {
+	    var qos = 0;
+	    if (methodArgs[2] && (typeof(methodArgs[2]) !== 'function')) {
+		    qos = methodArgs[2].qos;
+	    }
+	    context.req.stop({topic: methodArgs[0], qos: qos});
+    }
 };
 
 module.exports = MqttProbe;

--- a/probes/mysql-probe.js
+++ b/probes/mysql-probe.js
@@ -65,9 +65,11 @@ MySqlProbe.prototype.attach = function(name, target) {
  * 		duration:	the time for the request to respond
  */
 MySqlProbe.prototype.metricsEnd = function(probeData, method, methodArgs) {
-	probeData.timer.stop();
-	eventTimer = probeData.timer;
-	am.emit('mysql', {time: eventTimer.startTimeMillis, query: JSON.stringify(methodArgs[0]), duration: eventTimer.timeDelta});
+    if(probeData && probeData.timer) {
+	    probeData.timer.stop();
+	    eventTimer = probeData.timer;
+	    am.emit('mysql', {time: eventTimer.startTimeMillis, query: JSON.stringify(methodArgs[0]), duration: eventTimer.timeDelta});
+    }
 };
 
 /*
@@ -78,7 +80,8 @@ MySqlProbe.prototype.requestStart = function (probeData, method, methodArgs) {
 };
 
 MySqlProbe.prototype.requestEnd = function (probeData, method, methodArgs) {
-	probeData.req.stop({sql: JSON.stringify(methodArgs[0])});
+    if(probeData && probeData.req)
+	    probeData.req.stop({sql: JSON.stringify(methodArgs[0])});
 };
 
 module.exports = MySqlProbe;

--- a/probes/oracle-probe.js
+++ b/probes/oracle-probe.js
@@ -89,13 +89,15 @@ function addMonitoring(connection, probe) {
  * Lightweight metrics probe end for Oracle queries
  */
 OracleProbe.prototype.metricsEnd = function(probeData, method, methodArgs) {
-	probeData.timer.stop();
-	var query = methodArgs[0];
-	am.emit('oracle', {
-		time : probeData.timer.startTimeMillis,
-		query : query,
-		duration : probeData.timer.timeDelta
-	});
+    if(probeData && probeData.timer) {
+	    probeData.timer.stop();
+	    var query = methodArgs[0];
+	    am.emit('oracle', {
+		    time : probeData.timer.startTimeMillis,
+		    query : query,
+		    duration : probeData.timer.timeDelta
+	    });
+    }
 };
 
 /*
@@ -106,8 +108,9 @@ OracleProbe.prototype.requestStart = function (probeData, method, methodArgs) {
 };
 
 OracleProbe.prototype.requestEnd = function (probeData, method, methodArgs) {
-	var query = methodArgs[0];
-	probeData.req.stop({query:query});
+    if(probeData && probeData.req)
+	    var query = methodArgs[0];
+	    probeData.req.stop({query:query});
 };
 
 module.exports = OracleProbe;

--- a/probes/oracledb-probe.js
+++ b/probes/oracledb-probe.js
@@ -106,13 +106,15 @@ function addMonitoring(connection, probe) {
  * Lightweight metrics probe end for OracleDB queries
  */
 OracleDBProbe.prototype.metricsEnd = function(probeData, method, methodArgs) {
-	probeData.timer.stop();
-	var query = methodArgs[0];
-	am.emit('oracledb', {
-		time : probeData.timer.startTimeMillis,
-		query : query,
-		duration : probeData.timer.timeDelta
-	});
+    if(probeData && probeData.timer) {
+	    probeData.timer.stop();
+	    var query = methodArgs[0];
+	    am.emit('oracledb', {
+		    time : probeData.timer.startTimeMillis,
+		    query : query,
+		    duration : probeData.timer.timeDelta
+	    });
+    }
 };
 
 /*
@@ -123,8 +125,10 @@ OracleDBProbe.prototype.requestStart = function (probeData, method, methodArgs) 
 };
 
 OracleDBProbe.prototype.requestEnd = function (probeData, method, methodArgs) {
-	var query = methodArgs[0];
-	probeData.req.stop({query:query});
+    if(probeData && probeData.req) {
+	    var query = methodArgs[0];
+	    probeData.req.stop({query:query});
+    }
 };
 
 module.exports = OracleDBProbe;

--- a/probes/postgres-probe.js
+++ b/probes/postgres-probe.js
@@ -113,8 +113,10 @@ function monitorQuery(client,that) {
  *      duration:   the time for the request to respond
  */
 PostgresProbe.prototype.metricsEnd = function(probeData, method, methodArgs) {
-  probeData.timer.stop();
-  am.emit('postgres', {time: probeData.timer.startTimeMillis, query: methodArgs[0], duration: probeData.timer.timeDelta});
+  if(probeData && probeData.timer) {
+    probeData.timer.stop();
+    am.emit('postgres', {time: probeData.timer.startTimeMillis, query: methodArgs[0], duration: probeData.timer.timeDelta});
+  }
 };
 
 /*
@@ -126,7 +128,8 @@ PostgresProbe.prototype.requestStart = function (probeData, target, method, meth
 };
 
 PostgresProbe.prototype.requestEnd = function (probeData, method, methodArgs) {
-  probeData.req.stop({sql: methodArgs[0]});
+  if(probeData && probeData.req)
+    probeData.req.stop({sql: methodArgs[0]});
 };
 
 module.exports = PostgresProbe;

--- a/probes/redis-probe.js
+++ b/probes/redis-probe.js
@@ -139,8 +139,10 @@ RedisProbe.prototype.attach = function(name, target) {
  */
 
 RedisProbe.prototype.metricsEnd = function(probeData, cmd, methodArgs) {
-	probeData.timer.stop();
-	am.emit('redis', {time: probeData.timer.startTimeMillis, cmd: cmd, duration: probeData.timer.timeDelta});
+    if(probeData && probeData.timer) {
+	    probeData.timer.stop();
+	    am.emit('redis', {time: probeData.timer.startTimeMillis, cmd: cmd, duration: probeData.timer.timeDelta});
+    }
 };
 
 /*
@@ -152,9 +154,11 @@ RedisProbe.prototype.requestStart = function (probeData, cmd, methodArgs) {
 };
 
 RedisProbe.prototype.requestEnd = function (probeData, cmd, methodArgs) {
-	var context = {};
-	context.cmd = cmd;
-	probeData.req.stop(context);
+    if(probeData && probeData.req) {
+	    var context = {};
+	    context.cmd = cmd;
+	    probeData.req.stop(context);
+    }
 };
 
 module.exports = RedisProbe;

--- a/probes/socketio-probe.js
+++ b/probes/socketio-probe.js
@@ -135,8 +135,10 @@ SocketioProbe.prototype.attach = function(name, target) {
  * 		duration:	the time for the action to complete
  */
 SocketioProbe.prototype.metricsEnd = function(context, methodName, methodArgs) {
-	context.timer.stop();
-	am.emit('socketio', {time: context.timer.startTimeMillis, method: methodName, event: methodArgs[0], duration: context.timer.timeDelta});
+    if(context && context.timer) {
+	    context.timer.stop();
+	    am.emit('socketio', {time: context.timer.startTimeMillis, method: methodName, event: methodArgs[0], duration: context.timer.timeDelta});
+    }
 };
 
 /*
@@ -154,7 +156,8 @@ SocketioProbe.prototype.requestStart = function (context, methodName, methodArgs
 };
 
 SocketioProbe.prototype.requestEnd = function (context, methodName, methodArgs) {
-	context.req.stop({method: methodName, event: methodArgs[0]});
+    if(context && context.req)
+	    context.req.stop({method: methodName, event: methodArgs[0]});
 };
 
 module.exports = SocketioProbe;

--- a/probes/strong-mq-probe.js
+++ b/probes/strong-mq-probe.js
@@ -117,15 +117,17 @@ Strong_MQProbe.prototype.attach = function(name, target) {
  *		duration:	the time for the request to respond
  */
 Strong_MQProbe.prototype.metricsEnd = function(context, methodName, methodArgs, eventType) {
-	context.timer.stop();
-	// default to quality of service (qos) 0, as that's what the strong-mq module does
-	var eventData ={time: context.timer.startTimeMillis, duration: context.timer.timeDelta, type: eventType}
-	if( methodName == 'publish') {
-		eventData.method = methodName;
-	} else {
-		eventData.event = 'message';
-	}
-	am.emit('strong-mq', eventData);
+    if(context && context.timer) {
+	    context.timer.stop();
+	    // default to quality of service (qos) 0, as that's what the strong-mq module does
+	    var eventData ={time: context.timer.startTimeMillis, duration: context.timer.timeDelta, type: eventType}
+	    if( methodName == 'publish') {
+		    eventData.method = methodName;
+	    } else {
+		    eventData.event = 'message';
+	    }
+	    am.emit('strong-mq', eventData);
+    }
 };
 
 /*
@@ -141,7 +143,8 @@ Strong_MQProbe.prototype.requestStart = function (context, methodName, methodArg
 };
 
 Strong_MQProbe.prototype.requestEnd = function (context, methodName, methodArgs, socketType) {
-	context.req.stop({topic: methodArgs[0]});
+    if(context && context.req)
+	    context.req.stop({topic: methodArgs[0]});
 };
 
 module.exports = Strong_MQProbe;

--- a/probes/strongoracle-probe.js
+++ b/probes/strongoracle-probe.js
@@ -91,13 +91,15 @@ function addMonitoring(connection, probe) {
  * Lightweight metrics probe end for StrongOracle queries
  */
 StrongOracleProbe.prototype.metricsEnd = function(probeData, method, methodArgs) {
-	probeData.timer.stop();
-	var query = methodArgs[0];
-	am.emit('strong-oracle', {
-		time : probeData.timer.startTimeMillis,
-		query : query,
-		duration : probeData.timer.timeDelta
-	});
+    if(probeData && probeData.timer) {
+	    probeData.timer.stop();
+	    var query = methodArgs[0];
+	    am.emit('strong-oracle', {
+		    time : probeData.timer.startTimeMillis,
+		    query : query,
+		    duration : probeData.timer.timeDelta
+	    });
+    }
 };
 
 /*
@@ -108,8 +110,10 @@ StrongOracleProbe.prototype.requestStart = function (probeData, method, methodAr
 };
 
 StrongOracleProbe.prototype.requestEnd = function (probeData, method, methodArgs) {
-	var query = methodArgs[0];
-	probeData.req.stop({query:query});
+    if(probeData && probeData.req) {
+	    var query = methodArgs[0];
+	    probeData.req.stop({query:query});
+    }
 };
 
 module.exports = StrongOracleProbe;


### PR DESCRIPTION
Fixes #398 
Fixes the problem where errors could be thrown in the case where monitoring is switched on after a monitored call starts but before it ends (i.e. metricsEnd or requestEnd is called without a corresponding metricsStart or requestStart call).  We now just ignore these calls, which I think is reasonable.  Users should enable monitoring/requests before their application is started if they want to be sure to catch everthing.