### PR TITLE
Change Express Request probe type to 'express'

### DIFF
--- a/probes/express-probe.js
+++ b/probes/express-probe.js
@@ -93,7 +93,7 @@ ExpressProbe.prototype.metricsEnd = function(probeData, methodName, methodArgs) 
 
 // Heavyweight request probes for express queries 
 ExpressProbe.prototype.requestStart = function (probeData, method, methodArgs) {
-  probeData.req = request.startRequest( 'HTTP', 'request', false, probeData.timer );
+  probeData.req = request.startRequest( 'express', 'request', false, probeData.timer );
   probeData.req.setContext({url: methodArgs[0]});
 };
 


### PR DESCRIPTION
@seabaylea - This looks to fix the issue encountered in #390 but would like you to further clarify architechture with Response type field - should they be just 'HTTP' or 'DB' or should they be related to the actual probe e.g. 'express','mqlight'? Currently in the source we seem to have a half-and-half situation.

** Please do not pull until reviewed **