### PR TITLE
On process exit, remove latency methods from loop

### DIFF
--- a/index.js
+++ b/index.js
@@ -341,6 +341,11 @@ module.exports.start = function start () {
   var am = this;
   agent.start();
   process.on('exit', function () {
+    // take the event loop latency methods off the loop
+    if (latencyRunning === true) {
+        clearInterval(latencyCheckLoop);
+        clearInterval(latencyReportLoop);
+    }
     var headlessMode = agent.getOption('com.ibm.diagnostics.healthcenter.headless');
     am.stop();
     if(headlessMode == 'on') {


### PR DESCRIPTION
This was causing an assertion error on Node 7.7.4 on Windows:

Assertion failed: ((handle)->flags & UV__HANDLE_CLOSING) == 0, file src\win\loop-watcher.c, line 121

Caused by leaving work on the loop whilst attempting shutdown.