### PR TITLE
Stop node loop from using sstream << int on Windows

### DIFF
--- a/src/plugins/node/loop/nodeloopplugin.cpp
+++ b/src/plugins/node/loop/nodeloopplugin.cpp
@@ -73,6 +73,11 @@ static void GetLoopInformation(uv_timer_s *data, int status) {
 		mean = sum / num;
 	}
 
+#if defined(_WINDOWS)
+    std::string content = "NodeLoopData," + std::to_string(min) + "," +
+        std::to_string(max) + "," + std::to_string(num) + "," +
+        std::to_string(mean) + "\n";
+#else
 	std::stringstream contentss;
 	contentss << "NodeLoopData";
 	contentss << "," << min;
@@ -82,6 +87,7 @@ static void GetLoopInformation(uv_timer_s *data, int status) {
 	contentss << '\n';
 
 	std::string content = contentss.str();
+#endif
 
 	min = 9999;
 	max = 0;


### PR DESCRIPTION
This works around an issue with node 7.7.4 on Windows.