### PR TITLE
Undo Matt's changes

### DIFF
--- a/src/plugins/node/env/nodeenvplugin.cpp
+++ b/src/plugins/node/env/nodeenvplugin.cpp
@@ -251,31 +251,20 @@ static void GetNodeInformation(uv_async_t *async, int status) {
 		if (plugin::nodeName != "") {
 			contentss << "runtime.name=" << plugin::nodeName << '\n';
 		}
-#if defined(_WINDOWS)
-        contentss << "heap.size.limit=" << std::to_string(plugin::heapSizeLimit) << '\n';
+
+		contentss << "heap.size.limit=" << plugin::heapSizeLimit << '\n';
 		if (plugin::maxSemiSpaceSizeGuess > 0) {
-			contentss << "max.semi.space.size=" << std::to_string(plugin::maxSemiSpaceSizeGuess) << '\n';
+			contentss << "max.semi.space.size=" << plugin::maxSemiSpaceSizeGuess << '\n';
 		}
 		if (plugin::maxOldSpaceSizeGuess > 0) {
-			contentss << "max.old.space.size=" << std::to_string(plugin::maxOldSpaceSizeGuess) << '\n';
+			contentss << "max.old.space.size=" << plugin::maxOldSpaceSizeGuess << '\n';
 		}
 		if (plugin::maxHeapSizeGuess > 0) {
-			contentss << "max.heap.size=" << std::to_string(plugin::maxHeapSizeGuess) << '\n';
+			contentss << "max.heap.size=" << plugin::maxHeapSizeGuess << '\n';
 		}
-#else
-        contentss << "heap.size.limit=" << plugin::heapSizeLimit << '\n';
-        if (plugin::maxSemiSpaceSizeGuess > 0) {
-            contentss << "max.semi.space.size=" << plugin::maxSemiSpaceSizeGuess << '\n';
-        }
-        if (plugin::maxOldSpaceSizeGuess > 0) {
-            contentss << "max.old.space.size=" << plugin::maxOldSpaceSizeGuess << '\n';
-        }
-        if (plugin::maxHeapSizeGuess > 0) {
-            contentss << "max.heap.size=" << plugin::maxHeapSizeGuess << '\n';
-        }
-#endif
 
-        contentss << "command.line.arguments=" << plugin::commandLineArguments << '\n';
+
+		contentss << "command.line.arguments=" << plugin::commandLineArguments << '\n';
 		
 		std::string content = contentss.str();
 		monitordata data;

--- a/src/plugins/node/gc/nodegcplugin.cpp
+++ b/src/plugins/node/gc/nodegcplugin.cpp
@@ -154,19 +154,11 @@ void afterGC(GCType type, GCCallbackFlags flags) {
 
 	std::stringstream contentss;
 	contentss << "NodeGCData";
-#if defined(_WINDOWS)
-	contentss << "," << std::to_string(gcRealEnd); 
+	contentss << "," << gcRealEnd; 
 	contentss << "," << gcType;
-	contentss << "," << std::to_string(hs.total_heap_size());
-	contentss << "," << std::to_string(hs.used_heap_size());
-	contentss << "," << std::to_string(gcDuration);
-#else
-    contentss << "," << gcRealEnd;
-    contentss << "," << gcType;
-    contentss << "," << hs.total_heap_size();
-    contentss << "," << hs.used_heap_size();
-    contentss << "," << gcDuration;
-#endif
+	contentss << "," << hs.total_heap_size();
+	contentss << "," << hs.used_heap_size();
+	contentss << "," << gcDuration;
 	contentss << '\n';
 	
 	std::string content = contentss.str();

--- a/src/plugins/node/heap/nodeheapplugin.cpp
+++ b/src/plugins/node/heap/nodeheapplugin.cpp
@@ -68,13 +68,8 @@ static void GetHeapInformation(uv_timer_s *data, int status) {
 
 	std::stringstream contentss;
 	contentss << "NodeHeapData";
-#if defined(_WINDOWS)
-	contentss << "," << std::to_string(hs.total_heap_size());
-	contentss << "," << std::to_string(hs.used_heap_size());
-#else
-    contentss << "," << hs.total_heap_size();
-    contentss << "," << hs.used_heap_size();
-#endif
+	contentss << "," << hs.total_heap_size();
+	contentss << "," << hs.used_heap_size();
 	contentss << '\n';
 	
 	std::string content = contentss.str();

--- a/src/plugins/node/loop/nodeloopplugin.cpp
+++ b/src/plugins/node/loop/nodeloopplugin.cpp
@@ -75,17 +75,10 @@ static void GetLoopInformation(uv_timer_s *data, int status) {
 
 	std::stringstream contentss;
 	contentss << "NodeLoopData";
-#if defined(_WINDOWS)
-	contentss << "," << std::to_string(min);
-	contentss << "," << std::to_string(max);
-	contentss << "," << std::to_string(num);
-	contentss << "," << std::to_string(mean);
-#else
-    contentss << "," << min;
-    contentss << "," << max;
-    contentss << "," << num;
-    contentss << "," << mean;
-#endif
+	contentss << "," << min;
+	contentss << "," << max;
+	contentss << "," << num;
+	contentss << "," << mean;
 	contentss << '\n';
 
 	std::string content = contentss.str();

--- a/src/plugins/node/prof/nodeprofplugin.cpp
+++ b/src/plugins/node/prof/nodeprofplugin.cpp
@@ -155,26 +155,15 @@ static void ConstructNodeData(const CpuProfileNode *node, int id, int parentId, 
 
 		result << "{" << "\"functionName\":\"" << strFunction << "\",";
 		result << "\"url\":\"" << strScript << "\",";
-#if defined(_WINDOWS)
-		result << "\"lineNumber\":" << std::to_string(line) << ",";
-		result << "\"hitCount\":" << std::to_string(selfSamples) << ",";
-		result << "\"id\":" << std::to_string(id) << ",";
-#else
-        result << "\"lineNumber\":" << line << ",";
+		result << "\"lineNumber\":" << line << ",";
 		result << "\"hitCount\":" << selfSamples << ",";
 		result << "\"id\":" << id << ",";
-#endif
 		result << "\"children\":[";
 	}
 	
 	else{
-#if defined(_WINDOWS)
-		result << "NodeProfData,Node," << std::to_string(id) << ',' << std::to_string(parentId) << ',';
-		result << script << ',' << function << ',' << std::to_string(line) << ',' << std::to_string(selfSamples) << '\n';
-#else
-        result << "NodeProfData,Node," << id << ',' << parentId << ',';
-        result << script << ',' << function << ',' << line << ',' << selfSamples << '\n';
-#endif
+		result << "NodeProfData,Node," << id << ',' << parentId << ',';
+		result << script << ',' << function << ',' << line << ',' << selfSamples << '\n';
 	}
 	
 	// clean up
@@ -206,18 +195,10 @@ static char * ConstructData(const CpuProfile *profile) {
 
 	std::stringstream result;
 	if (jsonEnabled){
-#if defined(_WINDOWS)
-		result << "{\"date\":" << std::to_string(GetRealTime()) << ",";
-#else
 		result << "{\"date\":" << GetRealTime() << ",";
-#endif
 		result << "\"head\":";
 	}
-#if defined(_WINDOWS)
-	else result << "NodeProfData,Start," << std::to_string(GetRealTime()) << '\n';
-#else
-	else result << "NodeProfData,Start," << GetRealTime() << '\n';
-#endif
+	else result << "NodeProfData,Start," << GetRealTime() << '\n';	
 	visit(topRoot, ConstructNodeData, 0, result);
 	if (jsonEnabled){
 		result << "}";


### PR DESCRIPTION
We are currently unsure for the reason for these changes and it does brake profiling data as when pushing a double to std::to_string we get it formatted to 6 decimal places and this brakes the parsing. 