### PR TITLE
Fix probe for node 8 for issue #433

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "nan": "2.x",
     "tar": "2.x",
+    "semver": "^5.3.0",
     "jszip": "2.5.x"
   },
   "bundleDependencies": [
@@ -16,7 +17,6 @@
   ],
   "devDependencies": {
     "node-gyp": "3.x",
-    "semver": "^5.3.0",
     "tap": "7.x"
   },
   "scripts": {

--- a/probes/http-outbound-probe.js
+++ b/probes/http-outbound-probe.js
@@ -19,6 +19,14 @@ var request = require('../lib/request.js');
 var util = require('util');
 var url = require('url');
 var am = require('../');
+var semver = require('semver');
+
+var methods;
+if (semver.lt(process.version, '8.0.0')) {
+	methods = ['request'];
+} else {
+	methods = ['request', 'get'];
+}
 
 // Probe to instrument outbound http requests
 
@@ -33,7 +41,7 @@ HttpOutboundProbe.prototype.attach = function(name, target) {
         if(target.__outboundProbeAttached__) return target;
         target.__outboundProbeAttached__ = true;
        
-        aspect.around(target, 'request',
+        aspect.around(target, methods,
           // Before 'http.request' function
           function(obj, methodName, methodArgs, probeData) {
 
@@ -184,4 +192,5 @@ HttpOutboundProbe.prototype.requestEnd = function (probeData, method, url, res, 
 
 
 module.exports = HttpOutboundProbe;
+
 


### PR DESCRIPTION
Because of changes to the http module in node 8, we now need to probe both the request and the get method in our http-outbound probe.  Use semver to check the version of node as we must only do this on node 8, otherwise we will get double metrics on older node versions. Fixes issue #433.