### PR TITLE
Add additional info to the emitter in order to expose it to the api. …

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
     "semver": "^5.3.0",
     "jszip": "2.5.x"
   },
-  "bundleDependencies": [
-    "tar"
-  ],
   "devDependencies": {
     "codecov": "2.x",
     "node-gyp": "3.x",

--- a/probes/http-outbound-probe.js
+++ b/probes/http-outbound-probe.js
@@ -140,8 +140,8 @@ function formatURL(httpOptions) {
     }
     if(httpOptions.host) {
        url += httpOptions.host
-    } else  if(httpOptions.hostname) {
-       url += httpOptions.host
+    } else if(httpOptions.hostname) {
+       url += httpOptions.hostname
     } else {
        url += "localhost"
     }

--- a/probes/http-probe.js
+++ b/probes/http-probe.js
@@ -101,7 +101,8 @@ HttpProbe.prototype.filterUrl = function(req) {
 HttpProbe.prototype.metricsEnd = function(probeData, method, url, res, httpReq) {
     if(probeData && probeData.timer) {
 	    probeData.timer.stop();
-	    am.emit('http', {time: probeData.timer.startTimeMillis, method: method, url: url, duration: probeData.timer.timeDelta, header: res._header, statusCode: res.statusCode, contentType: res.getHeader('content-type'), requestHeader: httpReq.headers});
+	    var routePath = typeof(httpReq.route) === 'undefined' ? undefined : httpReq.route.path;
+	    am.emit('http', {time: probeData.timer.startTimeMillis, method: method, url: url, duration: probeData.timer.timeDelta, header: res._header, statusCode: res.statusCode, contentType: res.getHeader('content-type'), requestHeader: httpReq.headers, baseUrl: httpReq.baseUrl, route: routePath});
     }
 };
 


### PR DESCRIPTION
…Adding baseUrl and route info  allows for collecting data on urls that contain path variables. I accept and agree to be bound by the terms of the IBM Contributor License Agreement.