### PR TITLE
Fix ambiguous reference to 'debug' with Node 8.4.0

### DIFF
--- a/src/appmetrics.cpp
+++ b/src/appmetrics.cpp
@@ -173,7 +173,7 @@ static bool loadProperties() {
         std::string propFilename(fileJoin(*applicationDir, std::string(PROPERTIES_FILE)));
         loaded = loaderApi->loadPropertiesFile(propFilename.c_str());
     } else {
-        loaderApi->logMessage(debug, "Cannot load properties from application directory, main module not defined");
+        loaderApi->logMessage(::debug, "Cannot load properties from application directory, main module not defined");
     }
 
     // Load from current working directory, if possible
@@ -326,7 +326,7 @@ NAN_METHOD(start) {
         loaderApi->init();
 
         loaderApi->start();
-	
+
 	headless::start();
     }
     if (!initMonitorApi()) {
@@ -393,7 +393,7 @@ static void emitMessage(uv_async_t *handle, int status) {
     uv_mutex_unlock(messageListMutex);
 
     while(currentMessage != NULL ) {
-      
+
         Nan::TryCatch try_catch;
 
         const unsigned argc = 2;
@@ -456,7 +456,7 @@ static void sendData(const char* sourceId, unsigned int size, void *data) {
 }
 
 NAN_METHOD(nativeEmit) {
-    
+
     if (!isMonitorApiValid()) {
         Nan::ThrowError("Monitoring API is not initialized");
         //NanReturnUndefined();
@@ -477,7 +477,7 @@ NAN_METHOD(nativeEmit) {
         String::Utf8Value str(info[1]->ToString());
         char *c_arg = *str;
         contentss << c_arg;
-        
+
     } else {
         /*
          *  Error handling as we don't have a valid parameter
@@ -567,7 +567,7 @@ void lrtime(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     }
     timespec ts = {0, 0};
     clock_gettime(clock_id, &ts);
-      
+
 #if NODE_VERSION_AT_LEAST(0, 11, 0) // > v0.11+
     v8::Isolate* isolate = info.GetIsolate();
     v8::Local<v8::Array> result = v8::Array::New(isolate, 2);
@@ -578,7 +578,7 @@ void lrtime(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     result->Set(0, v8::Number::New(ts.tv_sec));
     result->Set(1, v8::Integer::NewFromUnsigned(ts.tv_nsec));
 #endif
-    
+
     info.GetReturnValue().Set(result);
 }
 #endif

--- a/src/plugins/node/env/nodeenvplugin.cpp
+++ b/src/plugins/node/env/nodeenvplugin.cpp
@@ -91,7 +91,7 @@ static Local<Object> GetProcessConfigObject() {
 	return Nan::GetCurrentContext()->Global()->Get(Nan::New<String>("process").ToLocalChecked())->ToObject()->Get(Nan::New<String>("config").ToLocalChecked())->ToObject();
 
 }
-	
+
 static std::string GetNodeVersion() {
 	Local<String> version = GetProcessObject()->Get(Nan::New<String>("version").ToLocalChecked())->ToString();
 	return ToStdString(version);
@@ -115,7 +115,7 @@ static std::string GetNodeArguments(const std::string separator="@@@") {
 			ss << ToStdString(nodeArgv->Get(i)->ToString());
 		}
 	}
-	
+
 	return ss.str();
 }
 
@@ -231,7 +231,7 @@ static void GetNodeInformation(uv_async_t *async, int status) {
 	Nan::GetHeapStatistics(&hs);
 	plugin::heapSizeLimit = hs.heap_size_limit();
 	uv_close((uv_handle_t*) async, cleanupHandle);
-	
+
 	if (plugin::nodeVersion != "") {
 		std::stringstream contentss;
 		contentss << "#EnvironmentSource\n";
@@ -241,7 +241,7 @@ static void GetNodeInformation(uv_async_t *async, int status) {
 			contentss << plugin::nodeTag;
 		}
 		contentss << '\n';
-		
+
 		contentss << "appmetrics.version=" << plugin::api.getProperty("appmetrics.version") << '\n'; // eg "1.0.4"
 		contentss << "agentcore.version=" << std::string(plugin::api.getProperty("agent.version")) << '\n'; // eg "3.0.7"
 
@@ -266,7 +266,7 @@ static void GetNodeInformation(uv_async_t *async, int status) {
 
 
 		contentss << "command.line.arguments=" << plugin::commandLineArguments << '\n';
-		
+
 		std::string content = contentss.str();
 		monitordata data;
 		data.persistent = false;
@@ -276,7 +276,7 @@ static void GetNodeInformation(uv_async_t *async, int status) {
 		data.data = content.c_str();
 		plugin::api.agentPushData(&data);
 	} else {
-		plugin::api.logMessage(debug, "[environment_node] Unable to get Node.js environment information");
+		plugin::api.logMessage(::debug, "[environment_node] Unable to get Node.js environment information");
 	}
 
 }
@@ -284,32 +284,32 @@ static void GetNodeInformation(uv_async_t *async, int status) {
 extern "C" {
 	NODEENVPLUGIN_DECL pushsource* ibmras_monitoring_registerPushSource(agentCoreFunctions api, uint32 provID) {
 		plugin::api = api;
-		plugin::api.logMessage(debug, "[environment_node] Registering push sources");
-	
+		plugin::api.logMessage(::debug, "[environment_node] Registering push sources");
+
 		pushsource *head = createPushSource(0, "environment_node");
 		plugin::provid = provID;
 		return head;
 	}
-	
+
 	NODEENVPLUGIN_DECL int ibmras_monitoring_plugin_init(const char* properties) {
 		return 0;
 	}
-	
+
 	NODEENVPLUGIN_DECL int ibmras_monitoring_plugin_start() {
 		plugin::api.logMessage(fine, "[environment_node] Starting");
-		
+
 		// Run GetNodeInformation() on the Node event loop
 		uv_async_t *async = new uv_async_t;
 		uv_async_init(uv_default_loop(), async, GetNodeInformation);
 		uv_async_send(async); // close and cleanup in call back
 		return 0;
 	}
-	
+
 	NODEENVPLUGIN_DECL int ibmras_monitoring_plugin_stop() {
 		plugin::api.logMessage(fine, "[environment_node] Stopping");
 		return 0;
 	}
-	
+
 	NODEENVPLUGIN_DECL const char* ibmras_monitoring_getVersion() {
 		return "1.0";
 	}

--- a/src/plugins/node/gc/nodegcplugin.cpp
+++ b/src/plugins/node/gc/nodegcplugin.cpp
@@ -40,7 +40,7 @@ namespace plugin {
 	agentCoreFunctions api;
 	uint32 provid = 0;
 	bool timingOK;
-	
+
 #ifdef _WINDOWS
 	LARGE_INTEGER gcSteadyStart, gcSteadyEnd;
 #elif defined(_LINUX) || defined(_AIX)
@@ -134,12 +134,12 @@ void beforeGC(v8::Isolate *isolate, GCType type, GCCallbackFlags flags) {
 
 void afterGC(v8::Isolate *isolate, GCType type, GCCallbackFlags flags) {
 	unsigned long long gcRealEnd;
-	
+
 	// GC pause time
 	if (plugin::timingOK) {
-		plugin::timingOK = GetSteadyTime(&plugin::gcSteadyEnd);	
+		plugin::timingOK = GetSteadyTime(&plugin::gcSteadyEnd);
 	}
-	const uint64 gcDuration = plugin::timingOK ? CalculateDuration(plugin::gcSteadyStart, plugin::gcSteadyEnd) : 0; 
+	const uint64 gcDuration = plugin::timingOK ? CalculateDuration(plugin::gcSteadyStart, plugin::gcSteadyEnd) : 0;
 
 	// Get "real" time
 	gcRealEnd = GetRealTime();
@@ -154,13 +154,13 @@ void afterGC(v8::Isolate *isolate, GCType type, GCCallbackFlags flags) {
 
 	std::stringstream contentss;
 	contentss << "NodeGCData";
-	contentss << "," << gcRealEnd; 
+	contentss << "," << gcRealEnd;
 	contentss << "," << gcType;
 	contentss << "," << static_cast<uint64_t>(hs.total_heap_size());
 	contentss << "," << static_cast<uint64_t>(hs.used_heap_size());
 	contentss << "," << gcDuration;
 	contentss << '\n';
-	
+
 	std::string content = contentss.str();
 
 	// Send data
@@ -188,17 +188,17 @@ pushsource* createPushSource(uint32 srcid, const char* name) {
 extern "C" {
 	NODEGCPLUGIN_DECL pushsource* ibmras_monitoring_registerPushSource(agentCoreFunctions api, uint32 provID) {
 	    plugin::api = api;
-	    plugin::api.logMessage(debug, "[gc_node] Registering push sources");
-	
+	    plugin::api.logMessage(::debug, "[gc_node] Registering push sources");
+
 	    pushsource *head = createPushSource(0, "gc_node");
 	    plugin::provid = provID;
 	    return head;
 	}
-	
+
 	NODEGCPLUGIN_DECL int ibmras_monitoring_plugin_init(const char* properties) {
 		return 0;
 	}
-	
+
 	NODEGCPLUGIN_DECL int ibmras_monitoring_plugin_start() {
 		plugin::api.logMessage(fine, "[gc_node] Starting");
 
@@ -212,7 +212,7 @@ extern "C" {
 		// TODO Unhook GC hooks...
 		return 0;
 	}
-	
+
 	NODEGCPLUGIN_DECL const char* ibmras_monitoring_getVersion() {
 		return "1.0";
 	}

--- a/src/plugins/node/heap/nodeheapplugin.cpp
+++ b/src/plugins/node/heap/nodeheapplugin.cpp
@@ -71,7 +71,7 @@ static void GetHeapInformation(uv_timer_s *data, int status) {
 	contentss << "," <<  static_cast<uint64_t>(hs.total_heap_size());
 	contentss << "," <<  static_cast<uint64_t>(hs.used_heap_size());
 	contentss << '\n';
-	
+
 	std::string content = contentss.str();
 
 	// Send data
@@ -100,17 +100,17 @@ pushsource* createPushSource(uint32 srcid, const char* name) {
 extern "C" {
 	NODEHEAPPLUGIN_DECL pushsource* ibmras_monitoring_registerPushSource(agentCoreFunctions api, uint32 provID) {
 	    plugin::api = api;
-	    plugin::api.logMessage(debug, "[heap_node] Registering push sources");
-	
+	    plugin::api.logMessage(::debug, "[heap_node] Registering push sources");
+
 	    pushsource *head = createPushSource(0, "heap_node");
 	    plugin::provid = provID;
 	    return head;
 	}
-	
+
 	NODEHEAPPLUGIN_DECL int ibmras_monitoring_plugin_init(const char* properties) {
 		return 0;
 	}
-	
+
 	NODEHEAPPLUGIN_DECL int ibmras_monitoring_plugin_start() {
 		plugin::api.logMessage(fine, "[heap_node] Starting");
 
@@ -126,14 +126,14 @@ extern "C" {
 //        uv_async_send(async); // close and cleanup in call back
         return 0;
 	}
-	
+
 	NODEHEAPPLUGIN_DECL int ibmras_monitoring_plugin_stop() {
 		plugin::api.logMessage(fine, "[heap_node] Stopping");
         uv_timer_stop(plugin::timer);
 		uv_close((uv_handle_t*) plugin::timer, cleanupHandle);
 		return 0;
 	}
-	
+
 	NODEHEAPPLUGIN_DECL const char* ibmras_monitoring_getVersion() {
 		return "1.0";
 	}

--- a/src/plugins/node/loop/nodeloopplugin.cpp
+++ b/src/plugins/node/loop/nodeloopplugin.cpp
@@ -127,7 +127,7 @@ void OnCheck(uv_check_t* handle) {
 extern "C" {
 	NODELOOPPLUGIN_DECL pushsource* ibmras_monitoring_registerPushSource(agentCoreFunctions api, uint32 provID) {
 	    plugin::api = api;
-	    plugin::api.logMessage(debug, "[loop_node] Registering push sources");
+	    plugin::api.logMessage(::debug, "[loop_node] Registering push sources");
 
 	    pushsource *head = createPushSource(0, "loop_node");
 	    plugin::provid = provID;


### PR DESCRIPTION
Appmetrics doesn't currently build against the latest Node 8, due to an ambiguous reference to 'debug'.  We are trying to use `debug` from the `loggingLevel` enum in omr-agentcore which unfortunately isn't in a namespace, but prefixing with `::` resolves to the global namespace and fixes the build error. 