### PR TITLE
Fix node-hc by readding arg shift

### DIFF
--- a/bin/appmetrics-cli.js
+++ b/bin/appmetrics-cli.js
@@ -19,7 +19,10 @@
 var node_args = process.execArgv;
 
 // First argv[0] should be 'node' and argv[1] the name of this file.
+// We want to IGNORE these 2 args
 var args = process.argv.splice(0);
+args.shift();
+args.shift();
 
 var arg = args.shift();
 while (typeof arg != 'undefined') {

--- a/extract_all_binaries.js
+++ b/extract_all_binaries.js
@@ -94,10 +94,10 @@ var ensureSupportedPlatformOrExit = function() {
 };
 
 var getSupportedNodeVersionOrExit = function() {
-  var supportedMajorVersions = "v4, v5, v6, v7, v8"
+  var supportedMajorVersions = 'v4, v5, v6, v7, v8';
   // version strings are of the format 'vN.N.N' where N is a positive integer.
   // we want the first N.
-  var majorVersion =  process.version.substring(1, process.version.indexOf('.'));
+  var majorVersion = process.version.substring(1, process.version.indexOf('.'));
   if (supportedMajorVersions.indexOf('v' + majorVersion) === -1) {
     console.log('Unsupported version ' + process.version + '. Trying rebuild.');
     fail();
@@ -136,7 +136,7 @@ function fail() {
 }
 
 function zipAndExtract(targetDir, relativeFilepath, destDir) {
-fs
+  fs
     .createReadStream(targetDir + relativeFilepath)
     .pipe(zlib.createGunzip())
     .on('error', function(err) {

--- a/probes/http-outbound-probe.js
+++ b/probes/http-outbound-probe.js
@@ -41,12 +41,12 @@ function getRequestItems(options) {
   var returnObject = { requestMethod: 'GET', urlRequested: '', headers: '' };
   if (options !== null) {
     var parsedOptions;
-    switch(typeof options) {
+    switch (typeof options) {
       case 'object':
         returnObject.urlRequested = formatURL(options);
         parsedOptions = options;
         break;
-      case 'string': 
+      case 'string':
         returnObject.urlRequested = options;
         parsedOptions = url.parse(options);
         break;

--- a/probes/https-outbound-probe.js
+++ b/probes/https-outbound-probe.js
@@ -37,12 +37,12 @@ function getRequestItems(options) {
   var returnObject = { requestMethod: 'GET', urlRequested: '', headers: '' };
   if (options !== null) {
     var parsedOptions;
-    switch(typeof options) {
+    switch (typeof options) {
       case 'object':
         returnObject.urlRequested = formatURL(options);
         parsedOptions = options;
         break;
-      case 'string': 
+      case 'string':
         returnObject.urlRequested = options;
         parsedOptions = url.parse(options);
         break;


### PR DESCRIPTION
Re-adding the removal of the first 2 args that was inadvertently removed as part of an eslint update.