### PR TITLE
Add event loop thread cpu usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,12 +247,14 @@ Emitted when a garbage collection (GC) cycle occurs in the underlying V8 runtime
 Emitted when all possible environment variables have been collected. Use `appmetrics.monitor.getEnvironment()` to access the available environment variables.
 
 ### Event: 'loop'
-Emitted every 60 seconds, summarising event tick information in time interval
+Emitted every 5 seconds, summarising event tick information in time interval
 * `data` (Object) the data from the event loop sample:
     * `count` (Number) the number of event loop ticks in the last interval.
     * `minimum` (Number) the shortest (i.e. fastest) tick in milliseconds.
     * `maximum` (Number) the longest (slowest) tick in milliseconds.
     * `average` (Number) the average tick time in milliseconds.
+    * `cpu_user` (Number) the percentage of 1 CPU used by the event loop thread in user code the last interval. This is a value between 0.0 and 1.0.
+    * `cpu_system` (Number) the percentage of 1 CPU used by the event loop thread in system code in the last interval. This is a value between 0.0 and 1.0.
 
 ### Event: 'memory'
 Emitted when a memory monitoring sample is taken.

--- a/appmetrics-api.js
+++ b/appmetrics-api.js
@@ -218,8 +218,8 @@ function API(agent, appmetrics) {
         maximum: parseFloat(values[2]),
         count: parseInt(values[3]),
         average: parseFloat(values[4]),
-        cpu_user: parseInt(values[5]),
-        cpu_sys: parseInt(values[6]),
+        cpu_user: parseFloat(values[5]),
+        cpu_system: parseFloat(values[6]),
       };
       that.emit('loop', loop);
     });

--- a/appmetrics-api.js
+++ b/appmetrics-api.js
@@ -218,6 +218,8 @@ function API(agent, appmetrics) {
         maximum: parseFloat(values[2]),
         count: parseInt(values[3]),
         average: parseFloat(values[4]),
+        cpu_user: parseInt(values[5]),
+        cpu_sys: parseInt(values[6]),
       };
       that.emit('loop', loop);
     });


### PR DESCRIPTION
This adds cpu percentage used during the last measurement interval to the event loop statistics.
This is different from the cpu usage for the process it is just the measurement for the event loop thread.

See: https://github.com/RuntimeTools/appmetrics-dash/issues/114 for more details on why this is required.

Currently this should work on Linux, Mac and AIX. Windows support could be added via a similar solution to: https://github.com/nodejs/node-report/issues/99