### PR TITLE
Expose new GC types introduced in v8 version 4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,13 @@ Emitted every 5 seconds, summarising sample based information of the event loop 
 Emitted when a garbage collection (GC) cycle occurs in the underlying V8 runtime.
 * `data` (Object) the data from the GC sample:
     * `time` (Number) the milliseconds when the sample was taken. This can be converted to a Date using `new Date(data.time)`.
-    * `type` (String) the type of GC cycle, either 'M' or 'S'.
+    * `type` (String) the type of GC cycle, either:
+      - `'M'`: MarkSweepCompact, aka "major"
+      - `'S'`: Scavenge, aka "minor"
+      - `'I'`: IncrementalMarking, aka "incremental" (only exists on node 5.x
+        and greater)
+      - '`W'`: ProcessWeakCallbacks, aka "weakcb" (only exists on node 5.x
+        and greater)
     * `size` (Number) the size of the JavaScript heap in bytes.
     * `used` (Number) the amount of memory used on the JavaScript heap in bytes.
     * `duration` (Number) the duration of the GC cycle in milliseconds.

--- a/src/plugins/node/gc/nodegcplugin.cpp
+++ b/src/plugins/node/gc/nodegcplugin.cpp
@@ -149,7 +149,17 @@ void afterGC(v8::Isolate *isolate, GCType type, GCCallbackFlags flags) {
 	gcRealEnd = GetRealTime();
 
 	// GC type
-	const char *gcType = (type == kGCTypeMarkSweepCompact) ? "M" : "S";
+	const char *gcType = NULL;
+        switch (type) {
+          case kGCTypeMarkSweepCompact: gcType = "M"; break;
+          case kGCTypeScavenge: gcType = "S"; break;
+#if NODE_VERSION_AT_LEAST(5, 0, 0)
+          case kGCTypeIncrementalMarking: gcType = "I"; break;
+          case kGCTypeProcessWeakCallbacks: gcType = "W"; break;
+#endif
+          // Should never happen, but call it minor if type is unrecognized.
+          default: gcType = "S"; break;
+        }
 
 	// GC heap stats
 	HeapStatistics hs;


### PR DESCRIPTION
Everything that was not kGCTypeMarkSweepCompact used to be mapped to "S"
(Scavenge), but that became wrong with 4.6, which has more GC types.

I've examined appmetrics-dash, it seems to treat all GC types identically, so this might not break it.

Conservatively, I would call it semver-major, but then again, maybe it can be considered a bug fix since the new GC types were introduced in node 5.x, but were all being classified as "Scavenge".