### PR TITLE
Expose new GC types introduced in v8 version 4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,13 @@ Emitted every 5 seconds, summarising sample based information of the event loop 
 Emitted when a garbage collection (GC) cycle occurs in the underlying V8 runtime.
 * `data` (Object) the data from the GC sample:
     * `time` (Number) the milliseconds when the sample was taken. This can be converted to a Date using `new Date(data.time)`.
-    * `type` (String) the type of GC cycle, either 'M' or 'S'.
+    * `type` (String) the type of GC cycle, either:
+      - `'M'`: MarkSweepCompact, aka "major"
+      - `'S'`: Scavenge, aka "minor"
+      - `'I'`: IncrementalMarking, aka "incremental" (only exists on node 5.x
+        and greater)
+      - '`W'`: ProcessWeakCallbacks, aka "weakcb" (only exists on node 5.x
+        and greater)
     * `size` (Number) the size of the JavaScript heap in bytes.
     * `used` (Number) the amount of memory used on the JavaScript heap in bytes.
     * `duration` (Number) the duration of the GC cycle in milliseconds.

--- a/src/plugins/node/gc/nodegcplugin.cpp
+++ b/src/plugins/node/gc/nodegcplugin.cpp
@@ -115,7 +115,17 @@ void afterGC(v8::Isolate *isolate, GCType type, GCCallbackFlags flags) {
 	gcRealEnd = GetRealTime();
 
 	// GC type
-	const char *gcType = (type == kGCTypeMarkSweepCompact) ? "M" : "S";
+	const char *gcType = NULL;
+        switch (type) {
+          case kGCTypeMarkSweepCompact: gcType = "M"; break;
+          case kGCTypeScavenge: gcType = "S"; break;
+#if NODE_VERSION_AT_LEAST(5, 0, 0)
+          case kGCTypeIncrementalMarking: gcType = "I"; break;
+          case kGCTypeProcessWeakCallbacks: gcType = "W"; break;
+#endif
+          // Should never happen, but call it minor if type is unrecognized.
+          default: gcType = "S"; break;
+        }
 
 	// GC heap stats
 	HeapStatistics hs;

--- a/tests/api_tests.js
+++ b/tests/api_tests.js
@@ -124,7 +124,8 @@ tap.test('GC Data', function(t) {
     // Test if all the GC data values are integers and type is either M or S.
     t.ok(isInteger(gcData.time), 'Timestamp is an integer');
 
-    t.ok(gcData.type === 'M' || gcData.type === 'S', 'Contains an expected GC type (expected "M" or "S")');
+    const gcTypes = {M: 1, S: 1, I: 1, W: 1};
+    t.ok(gcTypes[gcData.type], '"' + gcData.type + '" is an expected GC type');
 
     t.ok(isInteger(gcData.size), 'Heap size is an integer');
 


### PR DESCRIPTION
Everything that was not kGCTypeMarkSweepCompact used to be mapped to "S"
(Scavenge), but that became wrong with 4.6, which has more GC types.

Replaces #477 