### PR TITLE
Remove hardcoded port at 8000 to allow tests to run in parallel.

### DIFF
--- a/tests/heapdump/test-callback-without-filename.js
+++ b/tests/heapdump/test-callback-without-filename.js
@@ -25,7 +25,7 @@ function testFuncCall(test) {
     res.end();
   });
   server.on('listening', function() {
-    console.log('Listening on http://127.0.0.1:8000/');
+    console.log(`Listening on http://localhost:${server.address().port}/`);
     console.log('PID %d', process.pid);
 
     var heapSnapshotFile = 'heapdump-' + Date.now() + '.heapsnapshot';

--- a/tests/heapdump/test-callback.js
+++ b/tests/heapdump/test-callback.js
@@ -25,7 +25,7 @@ function testFuncCall(test) {
     res.end();
   });
   server.on('listening', function() {
-    console.log('Listening on http://127.0.0.1:8000/');
+    console.log(`Listening on http://localhost:${server.address().port}/`);
     console.log('PID %d', process.pid);
 
     var heapSnapshotFile = 'heapdump-*.heapsnapshot';

--- a/tests/heapdump/test-sigusr2.js
+++ b/tests/heapdump/test-sigusr2.js
@@ -28,7 +28,7 @@ function testSigUsr2(test) {
   });
 
   server.on('listening', function() {
-    console.log('Listening on http://127.0.0.1:8000/');
+    console.log(`Listening on http://localhost:${server.address().port}/`);
     console.log('now sending SIGUSR2 to %d', process.pid);
 
     var heapSnapshotFile = 'heapdump-*.heapsnapshot';

--- a/tests/probes/http-outbound-probe-test.js
+++ b/tests/probes/http-outbound-probe-test.js
@@ -39,7 +39,8 @@ monitor.on('http-outbound', function(data) {
 function checkHttpOutboundData(data, t) {
   t.ok(isInteger(data.time), 'Timestamp is an integer');
   t.equals(data.method, 'GET', 'Should report GET as HTTP request method');
-  t.equals(data.url, 'http://localhost:8000/', 'Should report http://localhost:8000/ as URL');
+  t.equals(data.url, `http://localhost:${server.address().port}/`,
+    `Should report http://localhost:${server.address().port}/ as URL`);
   if (data.requestHeaders) {
     t.equals(data.requestHeaders.hello, 'world', 'Should report world as value of hello header');
   }
@@ -55,17 +56,17 @@ function isNumeric(n) {
 
 var options = {
   host: 'localhost',
-  port: 8000,
+  port: server.address().port,
   headers: {
     hello: 'world',
   },
 };
 
 // Request with a callback
-http.get('http://localhost:8000/', function(res) {});
+http.get(`http://localhost:${server.address().port}/`, function(res) {});
 
 // Request without a callback
-http.get('http://localhost:8000/');
+http.get(`http://localhost:${server.address().port}/`);
 
 // Request with headers
 http.request(options).end();

--- a/tests/probes/http-probe-test.js
+++ b/tests/probes/http-probe-test.js
@@ -82,17 +82,17 @@ function isNumeric(n) {
 }
 
 // Request with a callback
-http.get('http://localhost:8000', function(res) {});
+http.get(`http://localhost:${server.address().port}/`, function(res) {});
 
 // Request without a callback
-http.get('http://localhost:8000');
+http.get(`http://localhost:${server.address().port}/`);
 
 // Enable requests
 monitor.enable('requests');
 monitor.disable('http');
 
 // Request with a callback
-http.get('http://localhost:8000', function(res) {});
+http.get(`http://localhost:${server.address().port}/`, function(res) {});
 
 // Request without a callback
-http.get('http://localhost:8000');
+http.get(`http://localhost:${server.address().port}/`);

--- a/tests/probes/https-outbound-probe-test.js
+++ b/tests/probes/https-outbound-probe-test.js
@@ -41,7 +41,8 @@ monitor.on('https-outbound', function(data) {
 function checkHttpOutboundData(data, t) {
   t.ok(isInteger(data.time), 'Timestamp is an integer');
   t.equals(data.method, 'GET', 'Should report GET as HTTP request method');
-  t.equals(data.url, 'https://localhost:8000/', 'Should report https://localhost:8000/ as URL');
+  t.equals(data.url, `https://localhost:${server.address().port}/`,
+    `Should report https://localhost:${server.address().port}/ as URL`);
   if (data.requestHeaders) {
     t.equals(data.requestHeaders.hello, 'world', 'Should report world as value of hello header');
   }
@@ -57,17 +58,17 @@ function isNumeric(n) {
 
 var options = {
   host: 'localhost',
-  port: 8000,
+  port: server.address().port,
   headers: {
     hello: 'world',
   },
 };
 
 // Request with a callback
-https.get('https://localhost:8000/', function(res) {});
+https.get(`https://localhost:${server.address().port}/`, function(res) {});
 
 // Request without a callback
-https.get('https://localhost:8000/');
+https.get(`https://localhost:${server.address().port}/`);
 
 // Request with headers
 https.request(options).end();

--- a/tests/probes/https-probe-test.js
+++ b/tests/probes/https-probe-test.js
@@ -82,14 +82,14 @@ function isNumeric(n) {
 }
 
 // Request with a callback
-https.get('https://localhost:8000/', function(res) {});
+https.get(`https://localhost:${server.address().port}/`, function(res) {});
 
 // Request without a callback
-https.get('https://localhost:8000/');
+https.get(`https://localhost:${server.address().port}/`);
 
 var options = {
   host: 'localhost',
-  port: 8000,
+  port: server.address().port,
   headers: {
     hello: 'world',
   },
@@ -104,8 +104,8 @@ setTimeout(function() {
   monitor.disable('https');
 
   // Request with a callback
-  https.get('https://localhost:8000/', function(res) {});
+  https.get(`https://localhost:${server.address().port}/`, function(res) {});
 
   // Request without a callback
-  https.get('https://localhost:8000/');
+  https.get(`https://localhost:${server.address().port}/`);
 }, 2000);

--- a/tests/require_tests.js
+++ b/tests/require_tests.js
@@ -25,7 +25,7 @@ tap.test('Calling require without start should not break', function(t) {
 
   // HTTP outbound request
   // (previously triggered http-outbound probe to emit an event which caused a SIGSEGV)
-  http.get('http://localhost:8000', function(res) {
+  http.get(`http://localhost:${server.address().port}/`, function(res) {
     server.close();
     t.end();
   });

--- a/tests/test_http_server.js
+++ b/tests/test_http_server.js
@@ -23,4 +23,4 @@ module.exports.server = http.createServer((req, res) => {
   res.end('Hello World');
 });
 
-this.server.listen(8000);
+this.server.listen(0);

--- a/tests/test_https_server.js
+++ b/tests/test_https_server.js
@@ -30,4 +30,4 @@ module.exports.server = https.createServer(httpsOptions, (req, res) => {
   res.end('Hello World');
 });
 
-this.server.listen(8000);
+this.server.listen(0);


### PR DESCRIPTION
This removes the use of the hardcoded port 8000 from the tests so that they can run in parallel.
- Where we request a port for a server we use 0 which causes the system to assign an unused port number.
- Where we connect to a port we get the port number from `server.address().port`.

See: https://nodejs.org/api/net.html#net_server_listen_port_host_backlog_callback
