### PR TITLE
calculate physical memory used on z/OS

### DIFF
--- a/src/plugins/node/memory/nodezmemoryplugin.cpp
+++ b/src/plugins/node/memory/nodezmemoryplugin.cpp
@@ -121,8 +121,9 @@ static int64 getTotalPhysicalMemorySize() {
 }
 
 static int64 getProcessPhysicalMemorySize() {
-  //TODO: see if we can improve this on z/OS
-  return -1;
+  size_t size;
+  uv_resident_set_memory(&size);
+  return size;
 }
 
 static int64 getProcessPrivateMemorySize() {


### PR DESCRIPTION
Use the already existing uv_resident_set_size to retrieve the physical memory used by the process.