### PR TITLE
Fix https probe after 8.9.1 revert

### DIFF
--- a/probes/https-outbound-probe.js
+++ b/probes/https-outbound-probe.js
@@ -25,8 +25,8 @@ var util = require('util');
 var semver = require('semver');
 
 var methods;
-// In Node.js < v8.9.0 'get' calls 'request' so we only instrument 'request'
-if (semver.lt(process.version, '8.9.0')) {
+// In Node.js < v9.0.0 'get' calls 'request' so we only instrument 'request'
+if (semver.lt(process.version, '9.0.0')) {
   methods = ['request'];
 } else {
   methods = ['request', 'get'];


### PR DESCRIPTION
As the previous change was reverted, and won't go into the 8.x release
line, we only need to do this for 9.0.0 and up.

Refs: https://github.com/nodejs/node/pull/16660

cc/ @stalleyj 

This means that newer versions of appmetrics will be broken for v8.9.0 only, if that's a problem I can complicate the check.