### PR TITLE
Require ibmapm on first initialisaton of appmetrics.

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,6 @@ if (global.Appmetrics) {
   exports = module.exports = global.Appmetrics;
 } else {
   // This instance is the global, do all the setup here
-  global.Appmetrics = module.exports;
   module.exports.VERSION = VERSION;
 
   var path = require('path');
@@ -380,4 +379,7 @@ if (global.Appmetrics) {
     return this;
   };
 
+  // Expose global instance when appmetrics is fully initialised.
+  global.Appmetrics = module.exports;
+  require('ibmapm-embed');
 }

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ if (global.Appmetrics) {
   exports = module.exports = global.Appmetrics;
 } else {
   // This instance is the global, do all the setup here
+  global.Appmetrics = module.exports;
   module.exports.VERSION = VERSION;
 
   var path = require('path');
@@ -378,8 +379,6 @@ if (global.Appmetrics) {
 
     return this;
   };
-
-  // Expose global instance when appmetrics is fully initialised.
-  global.Appmetrics = module.exports;
+  //Require the Node.js DC, when appmetrics is fully initialised.
   require('ibmapm-embed');
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "nan": "2.x",
     "tar": "2.x",
     "semver": "^5.3.0",
-    "jszip": "2.5.x"
+    "jszip": "2.5.x",
+    "ibmapm-embed": "^1.0.0"
   },
   "bundleDependencies": [
     "tar"


### PR DESCRIPTION
This code change is just like Howard's change https://github.com/hhellyer/appmetrics/commit/de7a636da225cd896fdaa8b1a4c7facd074647f9.
As we have create a new npm package ibmapm-embed, the ibmapm-embed has removed the appmetrics from package.json, and add a attach function. So change the require to "ibmapm-embed".