### PR TITLE
Surround APM require with try/catch

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,9 +475,10 @@ The npm package for this project uses a semver-parsable X.0.Z version number for
 Non-release versions of this project (for example on github.com/RuntimeTools/appmetrics) will use semver-parsable X.0.Z-dev.B version numbers, where X.0.Z is the last release with Z incremented and B is an integer. For further information on the development process go to the  [appmetrics wiki][3]: [Developing](https://github.com/RuntimeTools/appmetrics/wiki/Developing).
 
 ## Version
-4.0.0
+4.0.1
 
 ## Release History
+`4.0.1` - Bug fix release.  
 `4.0.0` - Remove node-hc and add support for preloading.  
 `3.1.3` - Packaging fix.  
 `3.1.2` - Bug fixes.  

--- a/extract_all_binaries.js
+++ b/extract_all_binaries.js
@@ -42,7 +42,7 @@ var AGENTCORE_PLATFORMS = [
   'os390-s390x',
 ];
 var AGENTCORE_VERSION = '3.2.6';
-var APPMETRICS_VERSION = '4.0.0';
+var APPMETRICS_VERSION = '4.0.1';
 
 var LOG_FILE = path.join(INSTALL_DIR, 'install.log');
 var logFileStream = fs.createWriteStream(LOG_FILE, { flags: 'a' });

--- a/index.js
+++ b/index.js
@@ -384,6 +384,5 @@ if (global.Appmetrics) {
     require('ibmapm-embed');
   } catch (err) {
     console.log("Error initializing APM");
-    console.error(err);
   }
 }

--- a/index.js
+++ b/index.js
@@ -380,5 +380,10 @@ if (global.Appmetrics) {
     return this;
   };
   // Require the Node.js DC, when appmetrics is fully initialised.
-  require('ibmapm-embed');
+  try {
+    require('ibmapm-embed');
+  } catch (err) {
+    console.log("Error initializing APM");
+    console.error(err);
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appmetrics",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "engines": {
     "node": ">=4"
   },


### PR DESCRIPTION
Due to error thrown when using preloading - see https://github.com/IBM-APM/node-ibmapm-embed/issues/2

Also updates version to 4.0.1