### PR TITLE
Correct travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ before_install:
   - git submodule update --init --recursive
 node_js:
   - "6"
-  - "4"
-  - "node"
+  - "8"
 os:
   - linux
 script: npm run-script travis


### PR DESCRIPTION
Travis has started building on Node 10 as default, we currently only support 6 and 8 so this PR updates the Travis config file to reflect that.