### PR TITLE
Explicitly state z/OS lib extensions to be so

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -9,6 +9,9 @@
       ['OS=="aix"', {
         "SHARED_LIB_SUFFIX": ".a",
       }],
+      ['OS in "os390 zos"', {
+        "SHARED_LIB_SUFFIX": ".so",
+      }],
     ],
   },
 
@@ -24,7 +27,9 @@
         "conditions": [
           ['OS=="aix"', {
             'product_extension': 'a',
-          },{
+          }],
+          ['OS in "os390 zos"', {
+            'product_extension': 'so',
           }],
         ],
       }],


### PR DESCRIPTION
This PR adds the conditions needed for z/OS built libraries to explicitly be built with a .so suffix.