### PR TITLE
Fix Node 10 build issues on Windows and update version numbers 

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -86,6 +86,7 @@
   "targets": [
     {
       "target_name": "omr-agentcore",
+      "win_delay_load_hook": "false",
       "type": "none",
       "dependencies": [
         "<(agentcoredir)/binding.gyp:external",
@@ -104,6 +105,7 @@
     },
     {
       "target_name": "appmetrics",
+      "win_delay_load_hook": "false",
       "sources": [
         "<(INTERMEDIATE_DIR)/appmetrics.cpp",
         "<(srcdir)/headlessutils.cpp",
@@ -129,6 +131,7 @@
     },
     {
       "target_name": "nodeenvplugin",
+      "win_delay_load_hook": "false",
       "type": "shared_library",
       "sources": [
         "<(srcdir)/plugins/node/env/nodeenvplugin.cpp",
@@ -136,6 +139,7 @@
     },
     {
       "target_name": "nodeheapplugin",
+      "win_delay_load_hook": "false",
       "type": "shared_library",
       "sources": [
         "<(srcdir)/plugins/node/heap/nodeheapplugin.cpp",
@@ -143,6 +147,7 @@
     },
     {
       "target_name": "nodeprofplugin",
+      "win_delay_load_hook": "false",
       "type": "shared_library",
       "sources": [
         "<(srcdir)/plugins/node/prof/nodeprofplugin.cpp",
@@ -150,6 +155,7 @@
     },
     {
       "target_name": "nodeloopplugin",
+      "win_delay_load_hook": "false",
       "type": "shared_library",
       "sources": [
         "<(srcdir)/plugins/node/loop/nodeloopplugin.cpp",
@@ -157,6 +163,7 @@
     },
     {
       "target_name": "nodegcplugin",
+      "win_delay_load_hook": "false",
       "type": "shared_library",
       "sources": [
         "<(srcdir)/plugins/node/gc/nodegcplugin.cpp",
@@ -164,6 +171,7 @@
     },
     {
       "target_name": "install",
+      "win_delay_load_hook": "false",
       "type": "none",
       "dependencies": [
         "omr-agentcore",

--- a/extract_all_binaries.js
+++ b/extract_all_binaries.js
@@ -43,8 +43,8 @@ var AGENTCORE_PLATFORMS = [
   'win32-x64',
   'os390-s390x',
 ];
-var AGENTCORE_VERSION = '3.2.8';
-var APPMETRICS_VERSION = '4.0.2';
+var AGENTCORE_VERSION = '3.2.9';
+var APPMETRICS_VERSION = '4.0.1';
 
 var LOG_FILE = path.join(INSTALL_DIR, 'install.log');
 var logFileStream = fs.createWriteStream(LOG_FILE, { flags: 'a' });

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "appmetrics",
-  "version": "4.0.2",
+  "version": "4.0.1",
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "description": "Node Application Metrics",
   "dependencies": {


### PR DESCRIPTION
Looks like appmetrics version number was accidentally incremented twice. Going back to 4.0.1 and increasing omr-agentcore to 3.2.9