### PR TITLE
upgrade to Node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,7 @@ node_js:
   - "12"
 os:
   - osx
+  - linux
+  - windows
 script: npm run-script travis
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: node_js
 before_install:
   - git submodule update --init --recursive
 node_js:
-  - "6"
   - "8"
   - "10"
+  - "12"
 os:
   - linux
 script: npm run-script travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ node_js:
   - "10"
   - "12"
 os:
-  - linux
+  - osx
 script: npm run-script travis
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,17 @@ node_js:
 os:
   - osx
   - linux
-  - windows
+
+matrix:
+  allow_failures:
+    - os: windows
+      node_js: "8"
+    - os: windows
+      node_js: "10"
+    - os: windows
+      node_js: "12"
+  fast_finish: true
+
+
 script: npm run-script travis
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,13 @@ os:
   - linux
 
 matrix:
+  include:
+    - os: windows
+      node_js: "8"
+    - os: windows
+      node_js: "10"
+    - os: windows
+      node_js: "12"
   allow_failures:
     - os: windows
       node_js: "8"

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -20,3 +20,4 @@ Authors ordered by first contribution:
  - Vladislav Botvin (https://github.com/darky)
  - John Barboza (https://github.com/jbarz)
  - Abdirahim Musse (https://github.com/ab-m)
+ - Richard Waller (https://github.com/rwalle61)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Node Application Metrics provides the following built-in data collection sources
  Redis              | Redis commands issued by the application
  Riak               | Riak methods called by the application
  Request tracking   | A tree of application requests, events and optionally trace (disabled by default)
- Function trace     | Tracing of application function calls that occur during a request (disabled by default)  
+ Function trace     | Tracing of application function calls that occur during a request (disabled by default)
 
 ## Performance overhead
 
@@ -140,7 +140,7 @@ Sets various properties on the appmetrics monitoring agent. If the agent has alr
 
 Property name        | Property value type      | Property description
 :--------------------|:-------------------------|:-----------------------------
- `applicationID`     | `string`                 | Specifies a unique identifier for the mqtt connection             
+ `applicationID`     | `string`                 | Specifies a unique identifier for the mqtt connection
  `mqtt`              | `string['off'\|'on']`    | Specifies whether the monitoring agent sends data to the mqtt broker. The default value is `'on'`
  `mqttHost`          | `string`                 | Specifies the host name of the mqtt broker
  `mqttPort`          | `string['[0-9]*']`       | Specifies the port number of the mqtt broker
@@ -418,14 +418,7 @@ Requests are a special type of event emitted by appmetrics.  All the probes name
 
 The Node Application Metrics agent supports the following runtime environments where a Node.js runtime is available:
 
-* **Node.js v4** on:
-  * 64-bit or 32-bit Windows (x64 or x86)
-  * 64-bit or 32-bit Linux (x64, x86, ppc64, ppc64le, s390, s390x)
-  * 64-bit AIX (ppc64)
-  * 64-bit macOS (x64)
-* **Node.js v6** on all of the above, plus:
-  * 64-bit runtime on z/OS (os390)
-* **Node.js v8** on:
+* **Node.js v8, 10, 12** on:
   * 64-bit Windows (x64)
   * 64-bit Linux (x64, ppc64, ppc64le, s390x)
   * 64-bit AIX (ppc64)
@@ -472,7 +465,7 @@ If a task uses the Node.js thread exclusively then shuts down the Node.js runtim
 The source code for Node Application Metrics is available in the [appmetrics project][6]. Information on working with the source code -- installing from source, developing, contributing -- is available on the [appmetrics wiki][3].
 
 ## License
-This project is released under an Apache 2.0 open source license.  
+This project is released under an Apache 2.0 open source license.
 
 ## Versioning scheme
 The npm package for this project uses a semver-parsable X.0.Z version number for releases, where X is incremented for breaking changes to the public API described in this document and Z is incremented for bug fixes **and** for non-breaking changes to the public API that provide new function.
@@ -484,41 +477,43 @@ Non-release versions of this project (for example on github.com/RuntimeTools/app
 
 This module adopts the [Module Long Term Support (LTS)](http://github.com/CloudNativeJS/ModuleLTS) policy, with the following End Of Life (EOL) dates:
 
-| Module Version   | Release Date | Minimum EOL | EOL With     | Status  |
-|------------------|--------------|-------------|--------------|---------|
-| V4.x.x	         | Jan 2018     | Dec 2019    |              | Current |
+| Module Version   | Release Date | Minimum EOL | EOL With     | Status      |
+|------------------|--------------|-------------|--------------|-------------|
+| V4.x.x           | Jan 2018     | Dec 2019    |              | Maintenance |
+| V5.x.x           | May 2019     | Dec 2020    |              | Current     |
 
 ## Version
-4.0.1
+5.0.0
 
 ## Release History
-`4.0.1` - Bug fix release including adding Node 10 support on Windows (Unix already working).  
-`4.0.0` - Remove node-hc and add support for preloading.  
-`3.1.3` - Packaging fix.  
-`3.1.2` - Bug fixes.  
-`3.1.1` - Node v6 on z/OS support.  
-`3.1.0` - HTTPS probe added. Remove support for Node v7.    
-`3.0.2` - Probe defect for Node 8 support.  
-`3.0.1` - Packaging bug fix to allow build from source if binary not present.  
-`3.0.0` - Remove express probe. Additional data available in http and request events. Code improvements.  
-`2.0.1` - Remove support for Node.js 0.10, 0.12, 5.  Add heapdump api call.  
-`1.2.0` - Add file data collection capability and option configuration via api.  
-`1.1.2` - Update agent core to 3.0.10, support Node.js v7.  
-`1.1.1` - Fix node-gyp rebuild failure and don't force MQTT broker to on  
-`1.1.0` - Bug fixes, improved MongoDB data, updated dependencies, CPU watchdog feature  
-`1.0.13` - Express probe, strong-supervisor integration  
-`1.0.12` - Appmetrics now fully open sourced under Apache 2.0 license  
-`1.0.11` - Bug fixes    
-`1.0.10` - Bug fixes  
-`1.0.9` - Loopback and Riak support, bug fixes and update to agent core 3.0.9.  
-`1.0.8` - Oracle support, bug fixes and api tests runnable using 'npm test'.  
-`1.0.7` - StrongOracle support, support for installing with a proxy, expose MongoDB, MQLight and MySQL events to connectors.  
-`1.0.6` - OracleDB support and bug fixes.  
-`1.0.5` - Expose HTTP events to connectors (including MQTT).  
-`1.0.4` - Redis, Leveldown, Postgresql, Memcached, MQLight and MQTT support, higher precision timings, and improved performance.  
-`1.0.3` - Node.js v4 support.  
-`1.0.2` - HTTP, MySQL, MongoDB, request tracking and function tracing support.  
-`1.0.1` - Mac OS X support, io.js v2 support.  
+`5.0.0` - Add Node 12 support, remove Node 6 support.
+`4.0.1` - Bug fix release including adding Node 10 support on Windows (Unix already working).
+`4.0.0` - Remove node-hc and add support for preloading.
+`3.1.3` - Packaging fix.
+`3.1.2` - Bug fixes.
+`3.1.1` - Node v6 on z/OS support.
+`3.1.0` - HTTPS probe added. Remove support for Node v7.
+`3.0.2` - Probe defect for Node 8 support.
+`3.0.1` - Packaging bug fix to allow build from source if binary not present.
+`3.0.0` - Remove express probe. Additional data available in http and request events. Code improvements.
+`2.0.1` - Remove support for Node.js 0.10, 0.12, 5.  Add heapdump api call.
+`1.2.0` - Add file data collection capability and option configuration via api.
+`1.1.2` - Update agent core to 3.0.10, support Node.js v7.
+`1.1.1` - Fix node-gyp rebuild failure and don't force MQTT broker to on
+`1.1.0` - Bug fixes, improved MongoDB data, updated dependencies, CPU watchdog feature
+`1.0.13` - Express probe, strong-supervisor integration
+`1.0.12` - Appmetrics now fully open sourced under Apache 2.0 license
+`1.0.11` - Bug fixes
+`1.0.10` - Bug fixes
+`1.0.9` - Loopback and Riak support, bug fixes and update to agent core 3.0.9.
+`1.0.8` - Oracle support, bug fixes and api tests runnable using 'npm test'.
+`1.0.7` - StrongOracle support, support for installing with a proxy, expose MongoDB, MQLight and MySQL events to connectors.
+`1.0.6` - OracleDB support and bug fixes.
+`1.0.5` - Expose HTTP events to connectors (including MQTT).
+`1.0.4` - Redis, Leveldown, Postgresql, Memcached, MQLight and MQTT support, higher precision timings, and improved performance.
+`1.0.3` - Node.js v4 support.
+`1.0.2` - HTTP, MySQL, MongoDB, request tracking and function tracing support.
+`1.0.1` - Mac OS X support, io.js v2 support.
 `1.0.0` - First release.
 
 [1]:https://marketplace.eclipse.org/content/ibm-monitoring-and-diagnostic-tools-health-center

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appmetrics",
-  "version": "4.0.1",
+  "version": "5.0.0",
   "engines": {
     "node": ">=6"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "codecov": "^3.1.0",
     "eslint": "^4.0.0",
     "eslint-config-strongloop": "^2.1.0",
-    "node-gyp": "3.x",
+    "node-gyp": "4.x",
     "prettier": "^1.4.4",
     "tap": "^12.0.1"
   },

--- a/src/appmetrics.cpp
+++ b/src/appmetrics.cpp
@@ -738,8 +738,6 @@ void init(Local<Object> exports, Local<Object> module) {
     /*
      * Set exported functions
      */
-    Isolate* isolate = v8::Isolate::GetCurrent();
-    Local<Context> context = Nan::GetCurrentContext();
     Nan::SetMethod(exports, asciiString("getOption").c_str(), getOption);
     Nan::SetMethod(exports, asciiString("setOption").c_str(), setOption);
     Nan::SetMethod(exports, asciiString("start").c_str(), start);
@@ -778,6 +776,7 @@ void init(Local<Object> exports, Local<Object> module) {
     loaderApi->setProperty("appmetrics.version", APPMETRICS_VERSION);
 
     /* Initialize watchdog directly so that bindings can be created */
+    Isolate* isolate = v8::Isolate::GetCurrent();
     watchdog::Initialize(isolate, exports);
 
     /*

--- a/src/appmetrics.cpp
+++ b/src/appmetrics.cpp
@@ -87,12 +87,12 @@ namespace monitorApi {
 
 static std::string toStdString(Local<String> s) {
     char *buf = new char[s->Length() + 1];
-    #if NODE_VERSION_AT_LEAST(10, 0, 0)
-        Isolate* isolate = v8::Isolate::GetCurrent();
-        s->WriteUtf8(isolate, buf);
-	#else
-        s->WriteUtf8(buf);
-	#endif
+#if NODE_VERSION_AT_LEAST(10, 0, 0)
+    Isolate* isolate = v8::Isolate::GetCurrent();
+    s->WriteUtf8(isolate, buf);
+#else
+    s->WriteUtf8(buf);
+#endif
 #if defined(_ZOS)
     __atoe(buf);
 #endif
@@ -358,7 +358,7 @@ NAN_METHOD(setOption) {
 NAN_METHOD(getOption) {
 	if (info.Length() > 0) {
 		Local<String> value = Nan::To<String>(info[0]).ToLocalChecked();
-    std::string property = loaderApi->getProperty(toStdString(value).c_str());
+        std::string property = loaderApi->getProperty(toStdString(value).c_str());
 #if NODE_VERSION_AT_LEAST(0, 11, 0) // > v0.11+
 		v8::Local<v8::String> v8str = v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), property.c_str());
 #else

--- a/src/appmetrics.cpp
+++ b/src/appmetrics.cpp
@@ -196,10 +196,14 @@ static std::string* getModuleDir(Local<Object> module) {
     return new std::string(portDirname(moduleFilename));
 }
 
+static Local<Object> getSubObject(Local<Object> parentObj, Local<String> subObjectName) {
+  Local<Value> subObjectValue = Nan::Get(parentObj, subObjectName).ToLocalChecked();
+  return Nan::To<Object>(subObjectValue).ToLocalChecked();
+}
+
 static Local<Object> getProcessObject() {
     Local<String> processString = Nan::New<String>(asciiString("process")).ToLocalChecked();
-    Local<Value> processValue = Nan::Get(Nan::GetCurrentContext()->Global(), processString).ToLocalChecked();
-    Local<Object> processObj = Nan::To<Object>(processValue).ToLocalChecked();
+    Local<Object> processObj = getSubObject(Nan::GetCurrentContext()->Global(), processString);
     return processObj;
 }
 
@@ -672,15 +676,14 @@ static bool isGlobalAgent(Local<Object> module) {
     Local<String> parentString = Nan::New<String>(asciiString("parent")).ToLocalChecked();
     Local<Value> parentValue = Nan::Get(module, parentString).ToLocalChecked();
     if (parentValue->IsObject()) {
-        Local<String> filenameString = Nan::New<String>(asciiString("filename")).ToLocalChecked();
         Local<Object> parentObj = Nan::To<Object>(parentValue).ToLocalChecked();
+        Local<String> filenameString = Nan::New<String>(asciiString("filename")).ToLocalChecked();
         Local<Value> filenameValue = Nan::Get(parentObj, filenameString).ToLocalChecked();
         if (
             filenameValue->IsString()
             && isAppMetricsFile("index.js", toStdString(Nan::To<String>(filenameValue).ToLocalChecked()))
         ) {
-            Local<Value> grandparentValue = Nan::Get(parentObj, parentString).ToLocalChecked();
-            Local<Object> grandparentObj = Nan::To<Object>(grandparentValue).ToLocalChecked();
+            Local<Object> grandparentObj = getSubObject(parentObj, parentString);
             Local<Value> gpfilenameValue = Nan::Get(grandparentObj, filenameString).ToLocalChecked();
             Local<String> gpfilenameString = Nan::To<String>(gpfilenameValue).ToLocalChecked();
             if (gpfilenameValue->IsString() && isAppMetricsFile("launcher.js", toStdString(gpfilenameString))) {

--- a/src/appmetrics.cpp
+++ b/src/appmetrics.cpp
@@ -197,10 +197,10 @@ static std::string* getModuleDir(Local<Object> module) {
 }
 
 static Local<Object> getProcessObject() {
-    Local<String> process = Nan::New<String>(asciiString("process")).ToLocalChecked();
-    return Nan::To<Object>(
-        Nan::GetCurrentContext()->Global()->Get(process)
-    ).ToLocalChecked();
+    Local<String> processString = Nan::New<String>(asciiString("process")).ToLocalChecked();
+    Local<Value> processValue = Nan::Get(Nan::GetCurrentContext()->Global(), processString).ToLocalChecked();
+    Local<Object> processObj = Nan::To<Object>(processValue).ToLocalChecked();
+    return processObj;
 }
 
 static std::string* findApplicationDir() {
@@ -686,9 +686,11 @@ static bool isGlobalAgent(Local<Object> module) {
             filenameValue->IsString()
             && isAppMetricsFile("index.js", toStdString(Nan::To<String>(filenameValue).ToLocalChecked()))
         ) {
-            Local<Value> grandparent = Nan::To<Object>(parentValue).ToLocalChecked()->Get(parentString);
-            Local<Value> gpfilename = Nan::To<Object>(grandparent).ToLocalChecked()->Get(filenameString);
-            if (gpfilename->IsString() && isAppMetricsFile("launcher.js", toStdString(Nan::To<String>(gpfilename).ToLocalChecked()))) {
+            Local<Value> grandparentValue = Nan::Get(parentObj, parentString).ToLocalChecked();
+            Local<Object> grandparentObj = Nan::To<Object>(grandparentValue).ToLocalChecked();
+            Local<Value> gpfilenameValue = Nan::Get(grandparentObj, filenameString).ToLocalChecked();
+            Local<String> gpfilenameString = Nan::To<String>(gpfilenameValue).ToLocalChecked();
+            if (gpfilenameValue->IsString() && isAppMetricsFile("launcher.js", toStdString(gpfilenameString))) {
                 return true;
             }
         }
@@ -703,10 +705,10 @@ static bool isGlobalAgentAlreadyLoaded(Local<Object> module) {
     Nan::HandleScope scope;
     Local<Object> cache = getRequireCache(module);
     Local<Context> context = Nan::GetCurrentContext();
-    Local<Array> props = cache->GetOwnPropertyNames(context).ToLocalChecked();
+    Local<Array> props = Nan::GetOwnPropertyNames(cache).ToLocalChecked();
     if (props->Length() > 0) {
         for (uint32_t i=0; i<props->Length(); i++) {
-            Local<Value> entry = props->Get(i);
+            Local<Value> entry = Nan::Get(props, i).ToLocalChecked();
             Local<String> entryString = Nan::To<String>(entry).ToLocalChecked();
             if (entry->IsString() && isAppMetricsFile("launcher.js", toStdString(entryString))) {
                 return true;

--- a/src/appmetrics.cpp
+++ b/src/appmetrics.cpp
@@ -356,18 +356,18 @@ NAN_METHOD(setOption) {
 
 // get property
 NAN_METHOD(getOption) {
-	if (info.Length() > 0) {
-		Local<String> value = Nan::To<String>(info[0]).ToLocalChecked();
+    if (info.Length() > 0) {
+        Local<String> value = Nan::To<String>(info[0]).ToLocalChecked();
         std::string property = loaderApi->getProperty(toStdString(value).c_str());
 #if NODE_VERSION_AT_LEAST(0, 11, 0) // > v0.11+
-		v8::Local<v8::String> v8str = v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), property.c_str());
+        v8::Local<v8::String> v8str = v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), property.c_str());
 #else
-		v8::Local<v8::String> v8str = v8::String::New(property.c_str(), strlen(property.c_str()));
+        v8::Local<v8::String> v8str = v8::String::New(property.c_str(), strlen(property.c_str()));
 #endif
-		info.GetReturnValue().Set<v8::String>(v8str);
-	} else {
-		loaderApi->logMessage(warning, "Incorrect number of parameters passed to getOption");
-	}
+        info.GetReturnValue().Set<v8::String>(v8str);
+    } else {
+        loaderApi->logMessage(warning, "Incorrect number of parameters passed to getOption");
+    }
 }
 
 NAN_METHOD(start) {

--- a/src/appmetrics.cpp
+++ b/src/appmetrics.cpp
@@ -740,66 +740,22 @@ void init(Local<Object> exports, Local<Object> module) {
      */
     Isolate* isolate = v8::Isolate::GetCurrent();
     Local<Context> context = Nan::GetCurrentContext();
-    exports->Set(
-        Nan::New<String>(asciiString("getOption")).ToLocalChecked(),
-        Nan::New<FunctionTemplate>(getOption)
-            ->GetFunction(context).ToLocalChecked()
-	);
-    exports->Set(
-		Nan::New<String>(asciiString("setOption")).ToLocalChecked(),
-		Nan::New<FunctionTemplate>(setOption)
-			->GetFunction(context).ToLocalChecked()
-	);
-    exports->Set(
-		Nan::New<String>(asciiString("start")).ToLocalChecked(),
-		Nan::New<FunctionTemplate>(start)
-			->GetFunction(context).ToLocalChecked()
-	);
-    exports->Set(
-		Nan::New<String>(asciiString("spath")).ToLocalChecked(),
-		Nan::New<FunctionTemplate>(spath)
-			->GetFunction(context).ToLocalChecked()
-	);
-    exports->Set(
-		Nan::New<String>(asciiString("stop")).ToLocalChecked(),
-		Nan::New<FunctionTemplate>(stop)
-			->GetFunction(context).ToLocalChecked()
-	);
-    exports->Set(
-		Nan::New<String>(asciiString("localConnect")).ToLocalChecked(),
-		Nan::New<FunctionTemplate>(localConnect)
-			->GetFunction(context).ToLocalChecked()
-	);
-    exports->Set(
-		Nan::New<String>(asciiString("nativeEmit")).ToLocalChecked(),
-		Nan::New<FunctionTemplate>(nativeEmit)
-			->GetFunction(context).ToLocalChecked()
-	);
-    exports->Set(
-		Nan::New<String>(asciiString("sendControlCommand")).ToLocalChecked(),
-		Nan::New<FunctionTemplate>(sendControlCommand)
-			->GetFunction(context).ToLocalChecked()
-	);
+    Nan::SetMethod(exports, asciiString("getOption").c_str(), getOption);
+    Nan::SetMethod(exports, asciiString("setOption").c_str(), setOption);
+    Nan::SetMethod(exports, asciiString("start").c_str(), start);
+    Nan::SetMethod(exports, asciiString("spath").c_str(), spath);
+    Nan::SetMethod(exports, asciiString("stop").c_str(), stop);
+    Nan::SetMethod(exports, asciiString("localConnect").c_str(), localConnect);
+    Nan::SetMethod(exports, asciiString("nativeEmit").c_str(), nativeEmit);
+    Nan::SetMethod(exports, asciiString("sendControlCommand").c_str(), sendControlCommand);
 #if !defined(_ZOS)
-    exports->Set(
-		Nan::New<String>(asciiString("setHeadlessZipFunction")).ToLocalChecked(),
-		Nan::New<FunctionTemplate>(setHeadlessZipFunction)
-			->GetFunction(context).ToLocalChecked()
-	);
+    Nan::SetMethod(exports, asciiString("setHeadlessZipFunction").c_str(), setHeadlessZipFunction);
 #endif
 #if defined(_LINUX)
-    exports->Set(
-        Nan::New<String>("lrtime").ToLocalChecked(),
-        Nan::New<FunctionTemplate>(lrtime)
-            ->GetFunction(context).ToLocalChecked()
-    );
+    Nan::SetMethod(exports, asciiString("lrtime").c_str(), lrtime);
 #endif
 #if NODE_VERSION_AT_LEAST(0, 11, 0) // > v0.11+
-    exports->Set(
-		Nan::New<String>(asciiString("getObjectHistogram")).ToLocalChecked(),
-		Nan::New<FunctionTemplate>(getObjectHistogram)
-			->GetFunction(context).ToLocalChecked()
-	);
+    Nan::SetMethod(exports, asciiString("getObjectHistogram").c_str(), getObjectHistogram);
 #endif
     /*
      * Initialize healthcenter core library

--- a/src/appmetrics.cpp
+++ b/src/appmetrics.cpp
@@ -504,9 +504,7 @@ NAN_METHOD(nativeEmit) {
 
     std::stringstream contentss;
     if (info[0]->IsString()) {
-        Isolate* isolate = v8::Isolate::GetCurrent();
-        // String::Utf8Value str(isolate, Nan::To<String>(info[0]).ToLocalChecked());
-        Nan::Utf8String str(info[0]); // https://github.com/nodejs/nan/blob/master/doc/v8_misc.md#nanutf8string
+        Nan::Utf8String str(info[0]);
         char *c_arg = *str;
         contentss << c_arg << ":";
     } else {
@@ -516,8 +514,6 @@ NAN_METHOD(nativeEmit) {
         return Nan::ThrowError(asciiString("First argument must a event name string").c_str());
     }
     if (info[1]->IsString()) {
-        Isolate* isolate = v8::Isolate::GetCurrent();
-        // String::Utf8Value str(isolate, Nan::To<String>(info[1]).ToLocalChecked());
         Nan::Utf8String str(info[1]);
         char *c_arg = *str;
         contentss << c_arg;
@@ -544,10 +540,7 @@ NAN_METHOD(sendControlCommand) {
     }
 
     if (info[0]->IsString() && info[1]->IsString()) {
-        Isolate* isolate = v8::Isolate::GetCurrent();
-        // String::Utf8Value topicArg(isolate, Nan::To<String>(info[0]).ToLocalChecked());
         Nan::Utf8String topicArg(info[0]);
-        // String::Utf8Value commandArg(isolate, Nan::To<String>(info[1]).ToLocalChecked());
         Nan::Utf8String commandArg(info[1]);
         std::string topic = std::string(*topicArg);
         std::string command = std::string(*commandArg);
@@ -704,7 +697,6 @@ static bool isGlobalAgent(Local<Object> module) {
 static bool isGlobalAgentAlreadyLoaded(Local<Object> module) {
     Nan::HandleScope scope;
     Local<Object> cache = getRequireCache(module);
-    Local<Context> context = Nan::GetCurrentContext();
     Local<Array> props = Nan::GetOwnPropertyNames(cache).ToLocalChecked();
     if (props->Length() > 0) {
         for (uint32_t i=0; i<props->Length(); i++) {

--- a/src/appmetrics.cpp
+++ b/src/appmetrics.cpp
@@ -190,9 +190,8 @@ static std::string fileJoin(const std::string& path, const std::string& filename
 
 static std::string* getModuleDir(Local<Object> module) {
     Local<String> filenameKey = Nan::New<String>(asciiString("filename")).ToLocalChecked();
-    // Local<String> filename = Nan::To<String>(module->Get(filenameKey)).ToLocalChecked();
     Local<Value> filenameValue = Nan::Get(module, filenameKey).ToLocalChecked();
-    Local<String> filenameString = Nan::To<String>(filename).ToLocalChecked();
+    Local<String> filenameString = Nan::To<String>(filenameValue).ToLocalChecked();
     std::string moduleFilename(toStdString(filenameString));
     return new std::string(portDirname(moduleFilename));
 }
@@ -207,9 +206,8 @@ static Local<Object> getProcessObject() {
 static std::string* findApplicationDir() {
     Local<String> mainModuleString = Nan::New<String>(asciiString("mainModule")).ToLocalChecked();
     Local<Value> mainModuleValue = Nan::Get(getProcessObject(), mainModuleString).ToLocalChecked();
-    // Local<Value> mainModule = getProcessObject()->Get(mainModuleString);
-    if (!mainModule->IsUndefined()) {
-        return getModuleDir(Nan::To<Object>(mainModule).ToLocalChecked());
+    if (!mainModuleValue->IsUndefined()) {
+        return getModuleDir(Nan::To<Object>(mainModuleValue).ToLocalChecked());
     }
     return NULL;
 }
@@ -679,18 +677,16 @@ static bool isAppMetricsFile(std::string expected, std::string potentialMatch) {
 static bool isGlobalAgent(Local<Object> module) {
     Nan::HandleScope scope;
     Local<String> parentString = Nan::New<String>(asciiString("parent")).ToLocalChecked();
-    // Local<Value> parent = module->Get(parentString);
     Local<Value> parentValue = Nan::Get(module, parentString).ToLocalChecked();
-    if (parent->IsObject()) {
+    if (parentValue->IsObject()) {
         Local<String> filenameString = Nan::New<String>(asciiString("filename")).ToLocalChecked();
-        Local<Object> parentObj = Nan::To<Object>(parent).ToLocalChecked();
-        // Local<Value> filename = parentObj->Get(filenameString);
+        Local<Object> parentObj = Nan::To<Object>(parentValue).ToLocalChecked();
         Local<Value> filenameValue = Nan::Get(parentObj, filenameString).ToLocalChecked();
         if (
-            filename->IsString()
-            && isAppMetricsFile("index.js", toStdString(Nan::To<String>(filename).ToLocalChecked()))
+            filenameValue->IsString()
+            && isAppMetricsFile("index.js", toStdString(Nan::To<String>(filenameValue).ToLocalChecked()))
         ) {
-            Local<Value> grandparent = Nan::To<Object>(parent).ToLocalChecked()->Get(parentString);
+            Local<Value> grandparent = Nan::To<Object>(parentValue).ToLocalChecked()->Get(parentString);
             Local<Value> gpfilename = Nan::To<Object>(grandparent).ToLocalChecked()->Get(filenameString);
             if (gpfilename->IsString() && isAppMetricsFile("launcher.js", toStdString(Nan::To<String>(gpfilename).ToLocalChecked()))) {
                 return true;

--- a/src/heapdump/heapdump.cc
+++ b/src/heapdump/heapdump.cc
@@ -13,7 +13,7 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #include "node.h"  // Picks up BUILDING_NODE_EXTENSION on Windows, see #30.
-
+#include "nan.h"
 #include "../plugins/node/prof/compat-inl.h"
 #include "uv.h"
 #include "v8-profiler.h"
@@ -49,7 +49,6 @@ namespace {
 using v8::Context;
 using v8::Function;
 using v8::FunctionTemplate;
-using v8::Handle;
 using v8::HandleScope;
 using v8::HeapSnapshot;
 using v8::Isolate;
@@ -103,7 +102,7 @@ inline C::ReturnType WriteSnapshot(const C::ArgumentType& args) {
 
   char filename[kMaxPath];
   if (args[0]->IsString()) {
-    String::Utf8Value filename_string(args[0]);
+    Nan::Utf8String filename_string(args[0]);
     snprintf(filename, sizeof(filename), "%s", *filename_string);
   } else {
     RandomSnapshotFilename(filename, sizeof(filename));
@@ -154,20 +153,23 @@ inline void RandomSnapshotFilename(char* buffer, size_t size) {
 
 inline C::ReturnType Configure(const C::ArgumentType& args) {
   C::ReturnableHandleScope handle_scope(args);
-  PlatformInit(args.GetIsolate(), args[0]->Int32Value());
+  PlatformInit(args.GetIsolate(), args[0]->Int32Value(Nan::GetCurrentContext()).FromJust());
   return handle_scope.Return();
 }
 
 inline void Initialize(Local<Object> binding) {
   Isolate* const isolate = Isolate::GetCurrent();
+  Local<Context> context = Nan::GetCurrentContext();
   binding->Set(C::String::NewFromUtf8(isolate, "kForkFlag"),
                C::Integer::New(isolate, kForkFlag));
   binding->Set(C::String::NewFromUtf8(isolate, "kSignalFlag"),
                C::Integer::New(isolate, kSignalFlag));
   binding->Set(C::String::NewFromUtf8(isolate, "configure"),
-               C::FunctionTemplate::New(isolate, Configure)->GetFunction());
+               C::FunctionTemplate::New(isolate, Configure)
+                ->GetFunction(context).ToLocalChecked());
   binding->Set(C::String::NewFromUtf8(isolate, "writeSnapshot"),
-               C::FunctionTemplate::New(isolate, WriteSnapshot)->GetFunction());
+               C::FunctionTemplate::New(isolate, WriteSnapshot)
+                ->GetFunction(context).ToLocalChecked());
 }
 
 NODE_MODULE(addon, Initialize)

--- a/src/objecttracker.cpp
+++ b/src/objecttracker.cpp
@@ -51,7 +51,7 @@ NAN_METHOD(getObjectHistogram) {
 #else
 	const HeapSnapshot* snapshot = heapProfiler->TakeSnapshot(snapshotName);
 #endif
-#if NODE_VERSION_AT_LEAST(4, 0, 0) // > v4.00+
+#if NODE_VERSION_AT_LEAST(4, 0, 0) // > v0.11+
 	// Title field removed in Node 4.x
 #else
 	snapshotName

--- a/src/objecttracker.cpp
+++ b/src/objecttracker.cpp
@@ -37,7 +37,7 @@ NAN_METHOD(getObjectHistogram) {
 
 	HeapProfiler *heapProfiler = isolate->GetHeapProfiler();
 
-#if NODE_VERSION_AT_LEAST(4, 0, 0) // > v0.11+
+#if NODE_VERSION_AT_LEAST(4, 0, 0) // > v4.00+
 	// Title field removed in Node 4.x
 #else
 	Local<String> snapshotName = String::NewFromUtf8(isolate, "snapshot");
@@ -51,7 +51,7 @@ NAN_METHOD(getObjectHistogram) {
 #else
 	const HeapSnapshot* snapshot = heapProfiler->TakeSnapshot(snapshotName);
 #endif
-#if NODE_VERSION_AT_LEAST(4, 0, 0) // > v0.11+
+#if NODE_VERSION_AT_LEAST(4, 0, 0) // > v4.00+
 	// Title field removed in Node 4.x
 #else
 	snapshotName
@@ -100,7 +100,7 @@ NAN_METHOD(getObjectHistogram) {
 		int64_t ncount = 0;
 		int64_t nsize = 0;
 		if( !(tupleval->IsNull() || tupleval->IsUndefined()) ) {
-			tuple = tupleval->ToObject();
+			tuple = Nan::To<Object>(tupleval).ToLocalChecked();
 
 			/* Nothing else can access the tuple or histogram objects,
 			 * if we've found an entry for "name" then it will have these
@@ -108,9 +108,9 @@ NAN_METHOD(getObjectHistogram) {
 			 * from Get.
 			 */
 			Local<Value> count = tuple->Get(countName);
-			ncount = count->IntegerValue();
+			ncount = count->IntegerValue(Nan::GetCurrentContext()).FromJust();
 			Local<Value> size = tuple->Get(sizeName);
-			nsize = size->IntegerValue();
+			nsize = size->IntegerValue(Nan::GetCurrentContext()).FromJust();
 
 		} else {
 			/* Create a new tuple and add it to the histogram.

--- a/src/objecttracker.cpp
+++ b/src/objecttracker.cpp
@@ -94,7 +94,7 @@ NAN_METHOD(getObjectHistogram) {
 			continue;
 		}
 
-		Local<Value> tupleval = histogram->Get(name);
+		Local<Value> tupleval = Nan::Get(histogram, name).ToLocalChecked();
 		Local<Object> tuple;
 
 		int64_t ncount = 0;
@@ -107,9 +107,9 @@ NAN_METHOD(getObjectHistogram) {
 			 * fields set. There's no need to check for null/undefined
 			 * from Get.
 			 */
-			Local<Value> count = tuple->Get(countName);
+			Local<Value> count = Nan::Get(tuple, countName).ToLocalChecked();
 			ncount = count->IntegerValue(Nan::GetCurrentContext()).FromJust();
-			Local<Value> size = tuple->Get(sizeName);
+			Local<Value> size = Nan::Get(tuple, sizeName).ToLocalChecked();
 			nsize = size->IntegerValue(Nan::GetCurrentContext()).FromJust();
 
 		} else {

--- a/src/plugins/node/env/nodeenvplugin.cpp
+++ b/src/plugins/node/env/nodeenvplugin.cpp
@@ -123,12 +123,10 @@ static std::string nativeString(std::string s) {
 }
 
 static Local<Object> GetProcessObject() {
-	Local<String> process = Nan::New<String>(asciiString("process")).ToLocalChecked();
-	return Nan::To<Object>(
-		Nan::GetCurrentContext()
-			->Global()
-			->Get(process)
-	).ToLocalChecked();
+	Local<String> processString = Nan::New<String>(asciiString("process")).ToLocalChecked();
+	Local<Value> processValue = Nan::Get(Nan::GetCurrentContext()->Global(), processString).ToLocalChecked();
+	Local<Object> processObj = Nan::To<Object>(processValue).ToLocalChecked();
+	return processObj;
 }
 
 static Local<Object> GetProcessConfigObject() {
@@ -161,9 +159,7 @@ static std::string GetNodeArguments(const std::string separator="@@@") {
 	std::stringstream ss;
 	Local<Object> process = GetProcessObject();
 	Local<String> execArgv = Nan::New<String>(asciiString("execArgv")).ToLocalChecked();
-	Local<Object> nodeArgv = Nan::To<Object>(
-		process->Get(execArgv)
-	).ToLocalChecked();
+	Local<Object> nodeArgv = Nan::To<Object>(process->Get(execArgv)).ToLocalChecked();
 
 	Local<String> length = Nan::New<String>(asciiString("length")).ToLocalChecked();
 	int64 nodeArgc = nodeArgv
@@ -192,9 +188,7 @@ size_t GuessSpaceSizeFromArgs(std::string argName) {
 
 	Local<Object> process = GetProcessObject();
 	Local<String> execArgv = Nan::New<String>(asciiString("execArgv")).ToLocalChecked();
-	Local<Object> nodeArgv = Nan::To<Object>(
-		process->Get(execArgv)
-	).ToLocalChecked();
+	Local<Object> nodeArgv = Nan::To<Object>(process->Get(execArgv)).ToLocalChecked();
 	Local<String> length = Nan::New<String>(asciiString("length")).ToLocalChecked();
 	int64 nodeArgc = nodeArgv
 		->Get(length)

--- a/src/plugins/node/env/nodeenvplugin.cpp
+++ b/src/plugins/node/env/nodeenvplugin.cpp
@@ -225,19 +225,19 @@ size_t GuessSpaceSizeFromArgs(std::string argName) {
 }
 
 static size_t GuessDefaultMaxOldSpaceSize() {
-	#if NODE_VERSION_AT_LEAST(12, 0, 0)
-		return Megabytes(700ul * (v8::internal::kApiSystemPointerSize / 4));
-	#else
-		return Megabytes(700ul * (v8::internal::kApiPointerSize / 4));
-	#endif
+#if NODE_VERSION_AT_LEAST(12, 0, 0)
+	return Megabytes(700ul * (v8::internal::kApiSystemPointerSize / 4));
+#else
+	return Megabytes(700ul * (v8::internal::kApiPointerSize / 4));
+#endif
 }
 
 static size_t GuessDefaultMaxSemiSpaceSize() {
-	#if NODE_VERSION_AT_LEAST(12, 0, 0)
-		return Megabytes(8ul * (v8::internal::kApiSystemPointerSize / 4));
-	#else
-		return Megabytes(8ul * (v8::internal::kApiPointerSize / 4));
-	#endif
+#if NODE_VERSION_AT_LEAST(12, 0, 0)
+	return Megabytes(8ul * (v8::internal::kApiSystemPointerSize / 4));
+#else
+	return Megabytes(8ul * (v8::internal::kApiPointerSize / 4));
+#endif
 }
 
 static size_t Align(size_t value, int alignment) {

--- a/src/plugins/node/env/nodeenvplugin.cpp
+++ b/src/plugins/node/env/nodeenvplugin.cpp
@@ -81,12 +81,12 @@ pushsource* createPushSource(uint32 srcid, const char* name) {
 
 static std::string ToStdString(Local<String> s) {
 	char *buf = new char[s->Length() + 1];
-	#if NODE_VERSION_AT_LEAST(10, 0, 0)
-        Isolate* isolate = v8::Isolate::GetCurrent();
-        s->WriteUtf8(isolate, buf);
-	#else
-        s->WriteUtf8(buf);
-	#endif
+#if NODE_VERSION_AT_LEAST(10, 0, 0)
+	Isolate* isolate = v8::Isolate::GetCurrent();
+	s->WriteUtf8(isolate, buf);
+#else
+	s->WriteUtf8(buf);
+#endif
 
 #if defined(_ZOS)
   __atoe(buf);

--- a/src/plugins/node/prof/compat-inl.h
+++ b/src/plugins/node/prof/compat-inl.h
@@ -291,6 +291,7 @@ ReturnType ReturnableHandleScope::Return(v8::Local<v8::Value> value) {
 }
 
 #else
+v8::CpuProfiler* cpu_profiler_ = nullptr;
 
 void CpuProfiler::StartCpuProfiling(v8::Isolate* isolate,
                                     v8::Local<v8::String> title) {
@@ -299,7 +300,12 @@ void CpuProfiler::StartCpuProfiling(v8::Isolate* isolate,
 #if !NODE_VERSION_AT_LEAST(3, 0, 0)
   return isolate->GetCpuProfiler()->StartCpuProfiling(title, record_samples);
 #else
-  return isolate->GetCpuProfiler()->StartProfiling(title, record_samples);
+  if (cpu_profiler_ == nullptr) {
+    cpu_profiler_ = v8::CpuProfiler::New(isolate);
+  }
+  if (cpu_profiler_ != nullptr) {
+    cpu_profiler_->StartProfiling(title, record_samples);
+  }
 #endif
 }
 
@@ -309,7 +315,11 @@ const v8::CpuProfile* CpuProfiler::StopCpuProfiling(
 #if !NODE_VERSION_AT_LEAST(3, 0, 0)
   return isolate->GetCpuProfiler()->StopCpuProfiling(title);
 #else
-  return isolate->GetCpuProfiler()->StopProfiling(title);
+  v8::CpuProfile* profile = nullptr;
+  if (cpu_profiler_ != nullptr) {
+    profile = cpu_profiler_->StopProfiling(title);
+  }
+  return profile;
 #endif
 }
 

--- a/src/plugins/node/prof/nodeprofplugin.cpp
+++ b/src/plugins/node/prof/nodeprofplugin.cpp
@@ -105,12 +105,12 @@ static char* NewCString(const std::string& s) {
 static bool ExtractV8String(const Local<String> v8string, char **cstring) {
 	*cstring = new char[v8string->Length() + 1];
 	if (*cstring == NULL) return false;
-	#if NODE_VERSION_AT_LEAST(10, 0, 0)
-        Isolate* isolate = v8::Isolate::GetCurrent();
-    	v8string->WriteUtf8(isolate, *cstring);
-	#else
-		v8string->WriteUtf8(*cstring);
-	#endif
+#if NODE_VERSION_AT_LEAST(10, 0, 0)
+	Isolate* isolate = v8::Isolate::GetCurrent();
+	v8string->WriteUtf8(isolate, *cstring);
+#else
+	v8string->WriteUtf8(*cstring);
+#endif
 	return true;
 }
 

--- a/src/plugins/node/prof/watchdog.h
+++ b/src/plugins/node/prof/watchdog.h
@@ -296,9 +296,13 @@ void Initialize(v8::Isolate* isolate, v8::Local<v8::Object> binding) {
 
   v8::Local<v8::FunctionTemplate> watchdog_activation_count_template =
       C::FunctionTemplate::New(isolate, WatchdogActivationCount);
+
+  Local<Context> context = Nan::GetCurrentContext();
   binding->Set(
       C::String::NewFromUtf8(isolate, "watchdogActivationCount"),
-      watchdog_activation_count_template->GetFunction());
+      watchdog_activation_count_template
+        ->GetFunction(context).ToLocalChecked()
+  );
 }
 
 }  // namespace watchdog

--- a/src/plugins/node/prof/watchdog.h
+++ b/src/plugins/node/prof/watchdog.h
@@ -297,7 +297,7 @@ void Initialize(v8::Isolate* isolate, v8::Local<v8::Object> binding) {
   v8::Local<v8::FunctionTemplate> watchdog_activation_count_template =
       C::FunctionTemplate::New(isolate, WatchdogActivationCount);
 
-  v8::Local<Context> context = Nan::GetCurrentContext();
+  v8::Local<v8::Context> context = Nan::GetCurrentContext();
   binding->Set(
       C::String::NewFromUtf8(isolate, "watchdogActivationCount"),
       watchdog_activation_count_template

--- a/src/plugins/node/prof/watchdog.h
+++ b/src/plugins/node/prof/watchdog.h
@@ -297,7 +297,7 @@ void Initialize(v8::Isolate* isolate, v8::Local<v8::Object> binding) {
   v8::Local<v8::FunctionTemplate> watchdog_activation_count_template =
       C::FunctionTemplate::New(isolate, WatchdogActivationCount);
 
-  Local<Context> context = Nan::GetCurrentContext();
+  v8::Local<Context> context = Nan::GetCurrentContext();
   binding->Set(
       C::String::NewFromUtf8(isolate, "watchdogActivationCount"),
       watchdog_activation_count_template

--- a/tests/api_tests.js
+++ b/tests/api_tests.js
@@ -347,7 +347,10 @@ function runNodeEnvTests(nodeEnvData, t) {
       'max.old.space.size is an integer (value was: ' + nodeEnvData['max.old.space.size'] + ')'
     );
     t.ok(parseInt(nodeEnvData['max.old.space.size']) > 0, 'max.old.space.size is positive');
-    if (semver.gt(process.version, '10.0.0')) {
+
+    if (semver.gt(process.version, '12.0.0')) {
+      t.skip();
+    } else if (semver.gt(process.version, '10.0.0')) {
       // heap size limit is now scaled by a factor - see
       // https://github.com/nodejs/node/blob/v10.x/deps/v8/src/heap/heap.cc#L250
       var maxHeapGuess = 2 * parseInt(nodeEnvData['max.semi.space.size']) + parseInt(nodeEnvData['max.old.space.size']);


### PR DESCRIPTION
# (These changes break Node 6. See below)
# Fix for Node 12:

### General information about the V8 API changes between Node 10 and 12
- Summary https://docs.google.com/document/d/1g8JFi8T_oAE_7uAri7Njtig7fKaPDfotU6huOa1alds/edit
- "v8/node deprecated APIs and how to handle them" https://github.com/bcoin-org/bcrypto/issues/7

### These fixes frequently involve the following:
- the `isolate` object - get via `Isolate* isolate = v8::Isolate::GetCurrent()`
- the `context` object - get via `Local<Context> context = Nan::GetCurrentContext()`
    - https://github.com/nodejs/nan/blob/master/doc/v8_misc.md#nangetcurrentcontext
- converting `MaybeLocal` types returned by many Nan functions to `Local` using `maybeLocalObj.ToLocalChecked()`

### Specific error fixes and my specific sources of information
- from `s->WriteUtf8(buf)` to `s->WriteUtf8(isolate, buf)`
    - https://github.com/nodejs/node/pull/22531/files#diff-f77b9fed8a3d7f7899ae2316e2bb3230R24
- from `X->ToString()` to `Nan::To<String>(X).ToLocalChecked()`
    - https://github.com/astro/node-expat/pull/196/files#diff-2b6f822b34553a6cadd4627d4dc9e84fR29
- from `X->ToObject()` to `Nan::To<Object>(X).ToLocalChecked()`
    - https://github.com/astro/node-expat/pull/196/files#diff-2b6f822b34553a6cadd4627d4dc9e84fR29
- from `X->ToInteger()` to `Nan::To<Integer>(X).ToLocalChecked()`
    - following the pattern of the above
    - see also https://github.com/nodejs/nan/blob/master/test/cpp/converters.cpp#L37
- from `X->GetOwnPropertyNames()` to `Nan::GetOwnPropertyNames(cache).ToLocalChecked()`
    - https://github.com/nodejs/nan/blob/master/doc/maybe_types.md#api_nan_get_own_property_names
    - or, to `X->GetOwnPropertyNames(context).ToLocalChecked()`
        - https://stackoverflow.com/questions/40533193/v8-c-how-to-get-object-key-values-provided-as-arguments
        - https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#a79a6e4d66049b9aa648ed4dfdb23e6eb
- from `X->GetFunction()` to `X->GetFunction(context).ToLocalChecked()`
    - https://www.nearform.com/page/7/?cat=-1
    - https://nodejs.org/api/addons.html
    - see alternative https://github.com/astro/node-expat/pull/196/files#diff-2b6f822b34553a6cadd4627d4dc9e84fR29
- from `String::Utf8Value X(Y)` to `Nan::Utf8Value X(Y)`
    - https://github.com/nodejs/nan/blob/master/doc/v8_misc.md#api_nan_utf8_string
    - https://github.com/microsoft/node-pty/pull/288/files#diff-8fc148e2d2217506b0e485a3033310feR174
    - https://v8docs.nodesource.com/node-8.11/d4/d1b/classv8_1_1_string_1_1_utf8_value.html
- from `X->Int32Value()` to `X->Int32Value(context).FromJust()`
    - https://github.com/microsoft/node-pty/pull/288/files#diff-8fc148e2d2217506b0e485a3033310feR174
- from `X->IntegerValue()` to `X->IntegerValue(context).FromJust()`
    - https://github.com/microsoft/node-pty/pull/288/files#diff-32a8618c58cb849e9b5535ba19ffacc5R186
- from `kApiPointerSize` to `kApiSystemPointerSize`
    - https://github.com/v8/v8/commit/81a654e7a0d8dc86896dd94773ad839b6ffc2383#diff-4637d1e4b9c1cbab90cbfd580aceff15R29
- from `isolate->GetCpuProfiler()` to ... (larger fix, because whereas the V8 engine previously had just 1 CpuProfiler, it now has multiple)
    - https://github.com/nodejs/node/pull/18959/files
    - https://v8docs.nodesource.com/node-10.6/d2/d34/classv8_1_1_cpu_profiler.html
- from `const Handle<String> X` to `const Local<String> X`
    - https://electronjs.org/blog/nodejs-native-addons-and-electron-5
    - https://github.com/microsoft/node-pty/pull/288/files#diff-8fc148e2d2217506b0e485a3033310feR174
- update `node-gyp` from v3 to v4
    - https://github.com/nodejs/node-gyp/issues/792
    - tbh I don't know in detail how this solves the problem

### Specific deprecation warning fixes and my specific sources of information
- from `X->Get(Y)` to `Nan::Get(X, Y).ToLocalChecked()`
    - https://github.com/nodejs/nan/blob/master/doc/maybe_types.md#nanget

- from `X->Set(Y, Z)` to `Nan::SetMethod(X, Y2, Z2)` 
    - (this is for for setting methods. To convert other forms of `X->Set(..)` to their Nan equivalents, see Nan docs https://github.com/nodejs/nan/blob/master/doc/methods.md#nansetprototypemethod and example https://github.com/astro/node-expat/pull/196/files#diff-2b6f822b34553a6cadd4627d4dc9e84fR29)
    - Nan docs https://github.com/nodejs/nan/blob/master/doc/methods.md#api_nan_set_method
    - at https://github.com/RuntimeTools/appmetrics/pull/576/files#diff-2419e406d80ff8bfd9b4fc942cc6b491R741, we are using NAN_METHOD macros https://github.com/RuntimeTools/appmetrics/pull/576/files#diff-2419e406d80ff8bfd9b4fc942cc6b491R358

### Notes
-  other forms of 'X->Set' will soon be deprecated - we should update our code

# These changes break Node 6:
### Problem:
<details><summary>Error output from `npm i` on Node 6</summary>

```
/Users/richard.waller@ibm.com/.node-gyp/6.17.1/include/node/v8.h:21:10: fatal error: 'utility' file not found
#include <utility>
         ^~~~~~~~~
1 warning and 1 error generated.
make: *** [Release/obj.target/appmetrics/geni/appmetrics.o] Error 1

```
</details>

This can be resolved simply following https://github.com/nodejs/node-gyp/issues/1564 and https://github.com/nodejs/node-gyp/issues/1574. However, that reveals that my upgrade to Node 12 is incompatible with Node 6:

<details><summary>Error output from `CXXFLAGS="-mmacosx-version-min=10.9" LDFLAGS="-mmacosx-version-min=10.9" npm i` on Node 6</summary>

```
In file included from ../src/plugins/node/prof/watchdog.h:21:
../src/plugins/node/prof/compat-inl.h:308:38: error: no member named 'New' in 'v8::CpuProfiler'
    cpu_profiler_ = v8::CpuProfiler::New(isolate);
                    ~~~~~~~~~~~~~~~~~^
Release/obj.target/appmetrics/geni/appmetrics.cpp:467:29: warning: 'Call' is deprecated [-Wdeprecated-declarations]
        listener->callback->Call(argc, argv);
                            ^
../node_modules/nan/nan.h:1673:3: note: 'Call' has been explicitly marked deprecated here
  NAN_DEPRECATED inline v8::Local<v8::Value>
  ^
../node_modules/nan/nan.h:103:40: note: expanded from macro 'NAN_DEPRECATED'
# define NAN_DEPRECATED __attribute__((deprecated))
                                       ^
Release/obj.target/appmetrics/geni/appmetrics.cpp:530:27: error: no matching constructor for initialization of
      'String::Utf8Value'
        String::Utf8Value str(isolate, Nan::To<String>(info[0]).ToLocalChecked());
                          ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/richard.waller@ibm.com/.node-gyp/6.17.1/include/node/v8.h:2428:14: note: candidate constructor not viable:
      requires single argument 'obj', but 2 arguments were provided
    explicit Utf8Value(Local<v8::Value> obj);
             ^
/Users/richard.waller@ibm.com/.node-gyp/6.17.1/include/node/v8.h:2438:5: note: candidate constructor not viable:
      requires 1 argument, but 2 were provided
    Utf8Value(const Utf8Value&);
    ^
Release/obj.target/appmetrics/geni/appmetrics.cpp:542:27: error: no matching constructor for initialization of
      'String::Utf8Value'
        String::Utf8Value str(isolate, Nan::To<String>(info[1]).ToLocalChecked());
                          ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/richard.waller@ibm.com/.node-gyp/6.17.1/include/node/v8.h:2428:14: note: candidate constructor not viable:
      requires single argument 'obj', but 2 arguments were provided
    explicit Utf8Value(Local<v8::Value> obj);
             ^
/Users/richard.waller@ibm.com/.node-gyp/6.17.1/include/node/v8.h:2438:5: note: candidate constructor not viable:
      requires 1 argument, but 2 were provided
    Utf8Value(const Utf8Value&);
    ^
Release/obj.target/appmetrics/geni/appmetrics.cpp:570:27: error: no matching constructor for initialization of
      'String::Utf8Value'
        String::Utf8Value topicArg(isolate, Nan::To<String>(info[0]).ToLocalChecked());
                          ^        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/richard.waller@ibm.com/.node-gyp/6.17.1/include/node/v8.h:2428:14: note: candidate constructor not viable:
      requires single argument 'obj', but 2 arguments were provided
    explicit Utf8Value(Local<v8::Value> obj);
             ^
/Users/richard.waller@ibm.com/.node-gyp/6.17.1/include/node/v8.h:2438:5: note: candidate constructor not viable:
      requires 1 argument, but 2 were provided
    Utf8Value(const Utf8Value&);
    ^
Release/obj.target/appmetrics/geni/appmetrics.cpp:572:27: error: no matching constructor for initialization of
      'String::Utf8Value'
        String::Utf8Value commandArg(isolate, Nan::To<String>(info[1]).ToLocalChecked());
                          ^          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/richard.waller@ibm.com/.node-gyp/6.17.1/include/node/v8.h:2428:14: note: candidate constructor not viable:
      requires single argument 'obj', but 2 arguments were provided
    explicit Utf8Value(Local<v8::Value> obj);
             ^
/Users/richard.waller@ibm.com/.node-gyp/6.17.1/include/node/v8.h:2438:5: note: candidate constructor not viable:
      requires 1 argument, but 2 were provided
    Utf8Value(const Utf8Value&);
    ^
1 warning and 5 errors generated.
make: *** [Release/obj.target/appmetrics/geni/appmetrics.o] Error 1

```
</details>

### Solution 1
Drop Node 6. This PR achieves this.

### Solution 2
Support Node 6 alongside 8, 10, and 12. We would need to spend considerable time converting probably ~60% of the fixes in this PR to use NAN and `if` blocks. 

### Ideal long-term solution
Rewrite much of appmetrics using N-API, but that is beyond the scope of this issue.