### PR TITLE
skip travis test-coverage bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "fix-eslint": "eslint --fix {bin,lib,probes,tests}/**/*.js *.js",
     "pretest": "eslint .",
     "test": "tap --reporter tap --timeout=120 tests/*tests.js tests/probes/http*test.js tests/headless_test.js",
-    "travis": "tap --reporter tap --timeout=120 tests/*tests.js tests/probes/http*test.js tests/headless_test.js --coverage",
-    "posttravis": "./get_code_cov.sh && tap --coverage-report=lcov && codecov --disable=gcov",
+    "travis": "npm test",
     "install": "node extract_all_binaries.js || node-gyp rebuild"
   },
   "directories": {


### PR DESCRIPTION
### Context

Travis tests have been failing (https://travis-ci.org/RuntimeTools/appmetrics/builds) since February (https://travis-ci.org/RuntimeTools/appmetrics/builds/503060787). We only just started looking at why when updating Appmetrics to run on Node 12 (https://github.com/RuntimeTools/appmetrics/issues/572). 

### Error report
The error is: 
```
# Subtest: tests/require_tests.js
[Tue May 28 11:05:50 2019] com.ibm.diagnostics.healthcenter.loader INFO: Node Application Metrics 4.0.1.201905281104 (Agent Core 3.2.9)
    # Subtest: Calling require without start should not break
        not ok 1 - Cannot read property 'f' of undefined
          ---
          stack: |
            TypeError:
                Object.<anonymous> (probes/trace-probe.js:15:109)
                Object.<anonymous> (probes/trace-probe.js:1)
                Object.replacementCompile (node_modules/append-transform/index.js:58:13)
                Generator.next (<anonymous>)
          type: TypeError
          tapCaught: testFunctionThrow
          test: Calling require without start should not break
          ...
        
        1..1
        # failed 1 test
    not ok 1 - Calling require without start should not break # time=862.618ms
```

The tests do not fail on my local Mac, but do fail with what seems to be the same error on local Linux as well as Travis (Mac, Linux and Windows: https://travis-ci.org/RuntimeTools/appmetrics/builds/538256997?utm_source=github_status&utm_medium=notification). 
- The tests pass everywhere if we take `--coverage` off the `npm run travis` script. 
- With `--coverage` on, the tests pass on local Linux, while the `esm` version is 3.2.11 or under. Perhaps this is because with `--coverage` on, `esm` removes its cache (https://github.com/tapjs/node-tap/issues/516#issuecomment-469883803). https://github.com/tapjs/node-tap/issues/517 might be related.

### Proposed solution
- Take `--coverage` off the `npm run travis` script, as it is blocking other work, such as upgrading Appmetrics to run on Node 12 (https://github.com/RuntimeTools/appmetrics/issues/572).
- Open new issue to get coverage working again


