### PR TITLE
Move http(s) timing contexts into the request level

### DIFF
--- a/probes/http-probe.js
+++ b/probes/http-probe.js
@@ -45,9 +45,11 @@ HttpProbe.prototype.attach = function(name, target) {
         // Filter out urls where filter.to is ''
         var traceUrl = that.filterUrl(httpReq);
         if (traceUrl !== '') {
-          that.metricsProbeStart(probeData, httpReq.method, traceUrl);
-          that.requestProbeStart(probeData, httpReq.method, traceUrl);
-          aspect.after(res, 'end', probeData, function(obj, methodName, args, probeData, ret) {
+          // Issue #590 - need to keep the probedata context separate from other requests
+          var context = {};
+          that.metricsProbeStart(context, httpReq.method, traceUrl);
+          that.requestProbeStart(context, httpReq.method, traceUrl);
+          aspect.after(res, 'end', context, function(obj, methodName, args, probeData, ret) {
             that.metricsProbeEnd(probeData, httpReq.method, traceUrl, res, httpReq);
             that.requestProbeEnd(probeData, httpReq.method, traceUrl, res, httpReq);
           });

--- a/probes/https-probe.js
+++ b/probes/https-probe.js
@@ -47,9 +47,11 @@ HttpsProbe.prototype.attach = function(name, target) {
         // Filter out urls where filter.to is ''
         var traceUrl = that.filterUrl(httpsReq);
         if (traceUrl !== '') {
-          that.metricsProbeStart(probeData, httpsReq.method, traceUrl);
-          that.requestProbeStart(probeData, httpsReq.method, traceUrl);
-          aspect.after(res, 'end', probeData, function(obj, methodName, args, probeData, ret) {
+          // Issue #590 - need to keep the probedata context separate from other requests
+          var context = {};
+          that.metricsProbeStart(context, httpsReq.method, traceUrl);
+          that.requestProbeStart(context, httpsReq.method, traceUrl);
+          aspect.after(res, 'end', context, function(obj, methodName, args, probeData, ret) {
             that.metricsProbeEnd(probeData, httpsReq.method, traceUrl, res, httpsReq);
             that.requestProbeEnd(probeData, httpsReq.method, traceUrl, res, httpsReq);
           });


### PR DESCRIPTION
This fixes issue #590 by moving the context object (which stores the event timings for start and stop) into the request level of the probes rather than the function level of aspect.js. Moving it to this scope prevents other http(s) events from overwriting the timings and causing groups of events to have the same start time and duration.
Passes `npm test`.