### PR TITLE
Disable watchdog when sigev_notify_thread_id is unavailable (fixes #582)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -21,3 +21,4 @@ Authors ordered by first contribution:
  - John Barboza (https://github.com/jbarz)
  - Abdirahim Musse (https://github.com/ab-m)
  - Richard Waller (https://github.com/rwalle61)
+ - Russell Howe (https://github.com/rhowe-gds)

--- a/src/plugins/node/prof/watchdog.h
+++ b/src/plugins/node/prof/watchdog.h
@@ -20,7 +20,7 @@
 #include "compat.h"
 #include "compat-inl.h"
 
-#if defined(__linux__) && (defined(__i386) || defined(__x86_64__)) || defined(sigev_notify_thread_id)
+#if defined(__linux__) && (defined(__i386) || defined(__x86_64__)) && defined(sigev_notify_thread_id)
 
 #include "util.h"
 


### PR DESCRIPTION
This is the case e.g. on Alpine Linux, which uses musl libc.

Correct the logic in the original commit
(48682de6d6187c15f9bb6b32bfa2f4c26733153f)

Note that I have only tested this compiles on Alpine 3.10 - it probably wants testing on non-Alpine systems