### PR TITLE
Build on nightly versions of Node 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,29 +2,52 @@ dist: trusty
 language: node_js
 before_install:
   - git submodule update --init --recursive
-node_js:
-  - "8"
-  - "10"
-  - "12"
-os:
-  - osx
-  - linux
 
 matrix:
   include:
+    - os: linux
+      node_js: "8"
+    - os: linux
+      node_js: "10"
+    - os: linux
+      node_js: "12"
+    - os: linux
+      node_js: "13"
+      env: NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly
+    - os: osx
+      node_js: "8"
+    - os: osx
+      node_js: "10"
+    - os: osx
+      node_js: "12"
+    - os: osx
+      node_js: "13"
+      env: NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly
     - os: windows
       node_js: "8"
     - os: windows
       node_js: "10"
     - os: windows
       node_js: "12"
+    - os: windows
+      node_js: "13"
+      env: NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly
   allow_failures:
+    - os: linux
+      node_js: "13"
+      env: NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly
+    - os: osx
+      node_js: "13"
+      env: NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly
     - os: windows
       node_js: "8"
     - os: windows
       node_js: "10"
     - os: windows
       node_js: "12"
+    - os: windows
+      node_js: "13"
+      env: NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly
   fast_finish: true
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,7 @@ matrix:
     - os: windows
       node_js: "12"
     - os: windows
-      node_js: "13"
-      env: NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly
+      node_js: "nightly/13"
   allow_failures:
     - os: linux
       node_js: "13"
@@ -46,8 +45,7 @@ matrix:
     - os: windows
       node_js: "12"
     - os: windows
-      node_js: "13"
-      env: NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly
+      node_js: "nightly/13"
   fast_finish: true
 
 


### PR DESCRIPTION
Building on Nightly versions of Node 13 gives us advance warning of whether or not Appmetrics will work on 13 when it comes out on 2019-10-22