### PR TITLE
Remove bundleDependencies from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
     "jszip": "2.5.x",
     "ibmapm-embed": ">=19.9.0"
   },
-  "bundleDependencies": [
-    "tar"
-  ],
   "devDependencies": {
     "codecov": "^3.1.0",
     "eslint": "^4.0.0",


### PR DESCRIPTION
Fixes #618.

This was put in so that `tar` would be available for Appmetrics install to use to extract the tar'd pre-built binaries. Now we don't supply pre-builds, `tar` can go back to just being a normal dependency.