### PR TITLE
Don't attempt to install probe for socket.io v3 or v4

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -23,3 +23,4 @@ Authors ordered by first contribution:
  - Richard Waller (https://github.com/rwalle61)
  - Russell Howe (https://github.com/rhowe-gds)
  - Gaby Baghdadi (https://github.com/gabylb)
+ - Mark Frost (https://github.com/frostmar)

--- a/probes/socketio-probe.js
+++ b/probes/socketio-probe.js
@@ -28,6 +28,16 @@ util.inherits(SocketioProbe, Probe);
 SocketioProbe.prototype.attach = function(name, target) {
   var that = this;
   if (name != 'socket.io') return target;
+
+  /*
+   * socket.io v2 directly exports the function to be patched
+   * socket.io v3 & v4 exports a factory function, with a Class as .Server which can't be patched successfully by the code below
+   */
+  if (target.Server) {
+    // don't attempt to patch v3+
+    return target;
+  }
+
   /*
 	 * Don't set __ddProbeAttached__ = true as we need to probe and return
 	 * the constructor each time


### PR DESCRIPTION
A quick workaround for issue https://github.com/RuntimeTools/appmetrics/issues/649
I'm afraid this isn't a proper fix, and only avoids installing the socket.io probe for newer versions where that doesn't currently work.

The socket.io probe only patches in successfully with socket.io v1 and v2
If a `.Server` class is on the socket.io export, this is probably v3+, so don't attempt to patch.