### PR TITLE
Upgrade jszip to 3.x to resolve CVE-2021-23413

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,8 @@
 {
   "extends": "strongloop",
   "env": {
-    "node": true
+    "node": true,
+    "es6": true
   },
   "parserOptions": { "ecmaVersion": 6 },
   "rules": {

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ headlesstestoutput*
 .nyc_output/
 package-lock.json
 resourceRegistry.log
+libagentcore.dylib
+nodejs_dc.log
+nodejs_restclient.log

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   },
   "description": "Node Application Metrics",
   "dependencies": {
+    "ibmapm-embed": ">=19.9.0",
+    "jszip": "^3.7.1",
     "nan": "2.x",
     "node-gyp": "5.x",
-    "tar": "4.x",
     "semver": "^5.3.0",
-    "jszip": "2.5.x",
-    "ibmapm-embed": ">=19.9.0"
+    "tar": "4.x"
   },
   "devDependencies": {
     "codecov": "^3.1.0",

--- a/tests/api_tests.js
+++ b/tests/api_tests.js
@@ -237,7 +237,7 @@ monitor.once('initialized', function() {
 function runCommonEnvTests(commonEnvData, t) {
   var ARCHS = ['x86', 'x86_64', 'ppc32', 'ppc64', 'ppc64le', 's390', 's390x'];
   var ZOS_ARCHS = ['3906', '2964', '2965', '2827', '2828', '2817', '2818'];
-  var OSES = ['AIX', 'Linux', 'Windows', 'Mac OS X', 'OS/390'];
+  var OSES = ['AIX', 'Linux', 'Windows', 'Mac OS X', 'macOS', 'OS/390'];
 
   t.ok(ARCHS.indexOf(commonEnvData['os.arch']) != -1, 'Contains a recognised value for os.arch', skipIfzOS);
   t.ok(ZOS_ARCHS.indexOf(commonEnvData['os.arch']) != -1, 'Contains a recognised value for z/OS os.arch', skipIfNotzOS);


### PR DESCRIPTION
Appmetrics currently uses `jszip@2.x` which has a prototype pollution vulnerability:

* [CVE-2021-23413](https://nvd.nist.gov/vuln/detail/CVE-2021-23413)
* [npm advisory 1774](https://www.npmjs.com/advisories/1774)
* [GitHub advisory GHSA-jg8v-48h5-wgxg](https://github.com/advisories/GHSA-jg8v-48h5-wgxg)

This PR upgrades the `jszip` dependency to `^3.7.0` and consequently tweaks the `headless_zip.js` functions to be more async friendly as `zip.generate()` has been replaced by `zip.generateAsync()`.

This fixes #655.

Additionally I had to fix a unit test failure that occurs when running on macOS 11 (caused by `os.name` now returning `macOS` rather than `Mac OS X`) to ensure my changes still passed the unit tests.