### PR TITLE
Use Python 3 in gyp bindings

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -23,3 +23,4 @@ Authors ordered by first contribution:
  - Richard Waller (https://github.com/rwalle61)
  - Russell Howe (https://github.com/rhowe-gds)
  - Gaby Baghdadi (https://github.com/gabylb)
+ - Alexey Kotlyarov (https://github.com/koterpillar)

--- a/binding.gyp
+++ b/binding.gyp
@@ -3,8 +3,8 @@
     "srcdir%": "./src",
     "agentcoredir%": "./omr-agentcore",
     "nandir%": "<!(node -e \"try {require('nan')}catch (e){console.log(e)}\")",
-    'build_id%': '.<!(["python", "./generate_build_id.py"])',
-    'appmetricsversion%':  '<!(["python", "./get_from_json.py", "./package.json", "version"])',
+    'build_id%': '.<!(["python3", "./generate_build_id.py"])',
+    'appmetricsversion%':  '<!(["python3", "./get_from_json.py", "./package.json", "version"])',
     "conditions": [
       ['OS=="aix"', {
         "SHARED_LIB_SUFFIX": ".a",
@@ -119,7 +119,7 @@
         'inputs': [ "<(srcdir)/appmetrics.cpp" ],
         'outputs': [ "<(INTERMEDIATE_DIR)/appmetrics.cpp" ],
         'action': [
-          'python',
+          'python3',
           './replace_in_file.py',
           '<(srcdir)/appmetrics.cpp',
           '<(INTERMEDIATE_DIR)/appmetrics.cpp',


### PR DESCRIPTION
Python 3 is already used by gyp, and `python` binary is removed from
e.g. macOS 13.2.

Fixes #653